### PR TITLE
Introduced GraphQLExecutionInputCustomizer

### DIFF
--- a/graphql/src/main/java/io/micronaut/configuration/graphql/DefaultGraphQLExecutionInputCustomizer.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/DefaultGraphQLExecutionInputCustomizer.java
@@ -37,8 +37,6 @@ public class DefaultGraphQLExecutionInputCustomizer implements GraphQLExecutionI
      */
     @Override
     public Publisher<ExecutionInput> customize(ExecutionInput executionInput, HttpRequest httpRequest) {
-        // TODO: first check if tests fail without line below...
-        // return Publishers.just(executionInput);
-        return null;
+        return Publishers.just(executionInput);
     }
 }

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/DefaultGraphQLExecutionInputCustomizer.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/DefaultGraphQLExecutionInputCustomizer.java
@@ -16,22 +16,29 @@
 
 package io.micronaut.configuration.graphql;
 
+import graphql.ExecutionInput;
+import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.http.HttpRequest;
+import org.reactivestreams.Publisher;
+
+import javax.inject.Singleton;
 
 /**
- * The GraphQL root builder that will be used to set the root object of the {@link graphql.ExecutionInput}.
+ * The default implementation for customizing GraphQL execution inputs.
  *
  * @author Marcel Overdijk
  * @since 1.0
- * @see graphql.ExecutionInput.Builder#root(Object)
  */
-public interface GraphQLRootBuilder {
+@Singleton
+public class DefaultGraphQLExecutionInputCustomizer implements GraphQLExecutionInputCustomizer {
 
     /**
-     * Builds the GraphQL root object to start the query execution on.
-     *
-     * @param httpRequest the HTTP request
-     * @return the GraphQL root object
+     * {@inheritDoc}
      */
-    Object build(HttpRequest httpRequest);
+    @Override
+    public Publisher<ExecutionInput> customize(ExecutionInput executionInput, HttpRequest httpRequest) {
+        // TODO: first check if tests fail without line below...
+        // return Publishers.just(executionInput);
+        return null;
+    }
 }

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLExecutionInputCustomizer.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLExecutionInputCustomizer.java
@@ -20,14 +20,12 @@ import graphql.ExecutionInput;
 import io.micronaut.http.HttpRequest;
 import org.reactivestreams.Publisher;
 
-import java.util.function.Consumer;
-
 /**
  * An interface for customizing the {@link ExecutionInput}. A custom implementation can be provided to e.g. set a context or root object.
  *
  * @author Marcel Overdijk
  * @since 1.0
- * @see graphql.ExecutionInput#transform(Consumer)
+ * @see graphql.ExecutionInput#transform(java.util.function.Consumer)
  */
 public interface GraphQLExecutionInputCustomizer {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLExecutionInputCustomizer.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLExecutionInputCustomizer.java
@@ -16,22 +16,27 @@
 
 package io.micronaut.configuration.graphql;
 
+import graphql.ExecutionInput;
 import io.micronaut.http.HttpRequest;
+import org.reactivestreams.Publisher;
+
+import java.util.function.Consumer;
 
 /**
- * The GraphQL context builder that will be used to set the context object of the {@link graphql.ExecutionInput}.
+ * An interface for customizing the {@link ExecutionInput}. A custom implementation can be provided to e.g. set a context or root object.
  *
  * @author Marcel Overdijk
  * @since 1.0
- * @see graphql.ExecutionInput.Builder#context(Object)
+ * @see graphql.ExecutionInput#transform(Consumer)
  */
-public interface GraphQLContextBuilder {
+public interface GraphQLExecutionInputCustomizer {
 
     /**
-     * Builds the GraphQL context object to pass to all data fetchers.
+     * Customizes the GraphQL execution input.
      *
+     * @param executionInput the execution input
      * @param httpRequest the HTTP request
      * @return the GraphQL context object
      */
-    Object build(HttpRequest httpRequest);
+    Publisher<ExecutionInput> customize(ExecutionInput executionInput, HttpRequest httpRequest);
 }


### PR DESCRIPTION
Introduced a `GraphQLExecutionInputCustomizer` in favour of the (deleted) `GraphQLContextBuilder ` and `GraphQLRootBuilder `.