### PR TITLE
Fixes index.html correct path to service extraction

### DIFF
--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphiQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphiQLController.java
@@ -119,6 +119,7 @@ public class GraphiQLController {
         String graphQLWsPath = graphQLWsConfiguration.isEnabled() ? graphQLWsConfiguration.getPath() : "";
         parameters.put("graphqlWsPath", graphQLWsPath);
         parameters.put("pageTitle", graphiQLConfiguration.getPageTitle());
+        parameters.put("graphiqlPath", graphiQLConfiguration.getPath());
         if (graphiQLConfiguration.getTemplateParameters() != null) {
             graphiQLConfiguration.getTemplateParameters().forEach((name, value) ->
                     // De-capitalize and de-hyphenate the parameter names.

--- a/graphql/src/main/resources/graphiql/index.html
+++ b/graphql/src/main/resources/graphiql/index.html
@@ -85,13 +85,24 @@
         history.replaceState(null, null, newSearch);
     }
 
+    // return path to service from current URL where GraphiQL was invoked
+    function pathToService() {
+        let graphiqlPath = '${graphiqlPath}'
+        let graphiqlPathLength = graphiqlPath.length
+        let removePathLength = window.location.pathname.endsWith('/') && !graphiqlPath.endsWith('/')
+            ? graphiqlPathLength + 1
+            : graphiqlPathLength;
+
+        return window.location.pathname.substr(0, window.location.pathname.length - removePathLength);
+    }
+
     // Defines a GraphQL fetcher using the fetch API. You're not required to
     // use fetch, and could instead implement graphQLFetcher however you like,
     // as long as it returns a Promise or Observable.
     function graphQLFetcher(graphQLParams) {
         // This example expects a GraphQL server at the path /graphql.
         // Change this to point wherever you host your GraphQL server.
-        return fetch('${graphqlPath}', {
+        return fetch(pathToService() + '${graphqlPath}', {
             method: 'post',
             headers: {
                 'Accept': 'application/json',
@@ -112,7 +123,7 @@
     let fetcher = graphQLFetcher;
     if('${graphqlWsPath}' !== ''){
       let wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      let fullWsPath = wsProtocol + '//' + window.location.hostname + ':' + window.location.port +'${graphqlWsPath}';
+      let fullWsPath = wsProtocol + '//' + window.location.hostname + ':' + window.location.port + pathToService() +'${graphqlWsPath}';
       let subscriptionsClient = new window.SubscriptionsTransportWs.SubscriptionClient(fullWsPath, { reconnect: true });
       fetcher = window.GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
     }


### PR DESCRIPTION
index.html correct path to service extraction from current URL where GraphiQL was invoked and fixes (#168)
GraphiQLController graphiQLPath as template parameter for extraction path on index.html side