### PR TITLE
Add api for customizing an GraphQLWs connection initialization

### DIFF
--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsConnectionInitializer.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsConnectionInitializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql.ws;
+
+import io.micronaut.websocket.WebSocketSession;
+
+/**
+ * An interface for initializing an GraphQLWs connection, e.g. for handling the custom payload.
+ *
+ * @author Nick Hensel
+ * @since 4.0
+ */
+
+public interface GraphQLWsConnectionInitializer {
+
+    /**
+     * This method is called, when a GQL_CONNECTION_INIT message is received
+     * @param request The GraphQlWs request
+     * @param session The WebSocketSession
+     * @since 4.0
+     */
+    void initialize(GraphQLWsInitRequest request, WebSocketSession session);
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsInitRequest.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsInitRequest.java
@@ -1,0 +1,10 @@
+package io.micronaut.configuration.graphql.ws;
+
+/**
+ * A class that represents an GQL_CONNECTION_INIT message
+ *
+ * @since 4.0
+ * @author Nick Hensel
+ */
+public class GraphQLWsInitRequest extends GraphQLWsRequest<String> {
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsOperations.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsOperations.java
@@ -31,7 +31,7 @@ import java.util.function.Function;
 @Singleton
 public class GraphQLWsOperations {
 
-    private ConcurrentHashMap<String, Subscription> activeOperations = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Subscription> activeOperations = new ConcurrentHashMap<>();
 
     /**
      * Cancels all containing subscriptions.

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsOperations.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsOperations.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
  * @since 1.3
  */
 @Singleton
-class GraphQLWsOperations {
+public class GraphQLWsOperations {
 
     private ConcurrentHashMap<String, Subscription> activeOperations = new ConcurrentHashMap<>();
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsRequest.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsRequest.java
@@ -15,16 +15,16 @@
  */
 package io.micronaut.configuration.graphql.ws;
 
-import io.micronaut.configuration.graphql.GraphQLRequestBody;
 import io.micronaut.core.annotation.Nullable;
 
 /**
  * Class to handle the message to and from the websocket.
  *
+ * @param <P> The payload type
  * @author Gerard Klijs
  * @since 1.3
  */
-public class GraphQLWsRequest {
+public abstract class GraphQLWsRequest<P> {
 
     private static final String TYPE_ERROR_MESSAGE = "Could not map %s to a known client type.";
 
@@ -32,7 +32,7 @@ public class GraphQLWsRequest {
     @Nullable
     private String id;
     @Nullable
-    private GraphQLRequestBody payload;
+    private P payload;
 
     /**
      * Get the type.
@@ -74,10 +74,10 @@ public class GraphQLWsRequest {
     /**
      * Get the payload.
      *
-     * @return payload as map, likely to contain a graphql query
+     * @return the payload
      */
     @Nullable
-    public GraphQLRequestBody getPayload() {
+    public P getPayload() {
         return payload;
     }
 
@@ -86,11 +86,11 @@ public class GraphQLWsRequest {
      *
      * @param payload the payload
      */
-    public void setPayload(@Nullable final GraphQLRequestBody payload) {
+    public void setPayload(@Nullable final P payload) {
         this.payload = payload;
     }
 
-    private ClientType fromString(String type) {
+    static ClientType fromString(String type) {
         for (ClientType clientType : ClientType.values()) {
             if (clientType.getType().equals(type)) {
                 return clientType;
@@ -108,7 +108,7 @@ public class GraphQLWsRequest {
         GQL_STOP("stop"),
         GQL_CONNECTION_TERMINATE("connection_terminate");
 
-        private String type;
+        private final String type;
 
         /**
          * Default constructor.

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsStartRequest.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsStartRequest.java
@@ -1,0 +1,12 @@
+package io.micronaut.configuration.graphql.ws;
+
+import io.micronaut.configuration.graphql.GraphQLRequestBody;
+
+/**
+ * A class that represents an GQL_START message (and any other except GQL_CONNECTION_INIT)
+ *
+ * @since 4.0
+ * @author Nick Hensel
+ */
+public class GraphQLWsStartRequest extends GraphQLWsRequest<GraphQLRequestBody> {
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsState.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsState.java
@@ -37,8 +37,8 @@ import static io.micronaut.configuration.graphql.ws.GraphQLWsResponse.ServerType
 @Singleton
 public class GraphQLWsState {
 
-    private ConcurrentSkipListSet<String> activeSessions = new ConcurrentSkipListSet<>();
-    private ConcurrentHashMap<String, GraphQLWsOperations> activeOperations = new ConcurrentHashMap<>();
+    private final ConcurrentSkipListSet<String> activeSessions = new ConcurrentSkipListSet<>();
+    private final ConcurrentHashMap<String, GraphQLWsOperations> activeOperations = new ConcurrentHashMap<>();
 
     /**
      * Sets the session to active.

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsState.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsState.java
@@ -35,7 +35,7 @@ import static io.micronaut.configuration.graphql.ws.GraphQLWsResponse.ServerType
  * @since 1.3
  */
 @Singleton
-class GraphQLWsState {
+public class GraphQLWsState {
 
     private ConcurrentSkipListSet<String> activeSessions = new ConcurrentSkipListSet<>();
     private ConcurrentHashMap<String, GraphQLWsOperations> activeOperations = new ConcurrentHashMap<>();

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsClient.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsClient.groovy
@@ -19,7 +19,7 @@ abstract class GraphQLWsClient implements AutoCloseable {
     private final GraphQLJsonSerializer serializer
 
     GraphQLWsClient(GraphQLJsonSerializer serializer) {
-        this.serializer = serializer;
+        this.serializer = serializer
     }
 
     @OnMessage
@@ -67,7 +67,7 @@ class SerializableRequest {
 
     String type
     String id
-    GraphQLRequestBody payload;
+    Object payload
 
     SerializableRequest(GraphQLWsRequest request){
         this.type = request.getType().getType()

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsKeepAliveSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsKeepAliveSpec.groovy
@@ -23,11 +23,11 @@ class GraphQLWsKeepAliveSpec extends Specification {
     WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, embeddedServer.getURI())
 
     @Shared
-    GraphQLWsClient graphQLWsClient = Flux.from(wsClient.connect(GraphQLWsClient, "/ka-ws")).blockFirst();
+    GraphQLWsClient graphQLWsClient = Flux.from(wsClient.connect(GraphQLWsClient, "/ka-ws")).blockFirst()
 
     void "test keep alive starts and stops"() {
         given:
-        GraphQLWsRequest request = new GraphQLWsRequest()
+        GraphQLWsRequest request = new GraphQLWsStartRequest()
         request.setType(GraphQLWsRequest.ClientType.GQL_CONNECTION_INIT.getType())
 
         when:


### PR DESCRIPTION
This pr adds an API for customizing the connection initialization and handling the payload. The custom payload in GQL_CONNECTION_INIT is often used for e.g. authentication.

This pr contains a breaking change, so I set the `@since` version to 4.0 (the next expectable major release):
- `GraphQLWsRequest` is now abstract and 2 implementing classes where introduced: `GraphQLWsStartRequest` (old behavior) and `GraphQLWsInitRequest`