### PR TITLE
Fixed reading of keep-alive-enabled property

### DIFF
--- a/graphql/src/main/java/io/micronaut/configuration/graphql/apollo/ws/GraphQLApolloWsKeepAlive.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/apollo/ws/GraphQLApolloWsKeepAlive.java
@@ -32,7 +32,7 @@ import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsRespon
  * @since 1.3
  */
 @Singleton
-@Requires(property = GraphQLApolloWsConfiguration.KEEP_ALIVE_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(property = GraphQLConfiguration.PREFIX + "." + GraphQLApolloWsConfiguration.KEEP_ALIVE_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 public class GraphQLApolloWsKeepAlive {
 
     private final WebSocketBroadcaster broadcaster;

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/apollo/ws/GraphQLApolloWsConfigurationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/apollo/ws/GraphQLApolloWsConfigurationSpec.groovy
@@ -21,6 +21,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.context.DefaultApplicationContext
 import io.micronaut.context.env.Environment
 import io.micronaut.context.env.PropertySource
+import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.websocket.annotation.ServerWebSocket
 import spock.lang.Specification
 
@@ -108,6 +109,24 @@ class GraphQLApolloWsConfigurationSpec extends Specification {
 
         expect:
         !context.getBean(GraphQLApolloWsConfiguration).enabled
+
+        cleanup:
+        context.close()
+    }
+
+    void "test bean not created when graphql websocket keepalive disabled"() {
+        given:
+        ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
+        context.environment.addPropertySource(PropertySource.of(
+                ["graphql.graphql-apollo-ws.keep-alive-enabled": false]
+        ))
+        context.start()
+
+        when:
+        context.getBean(GraphQLApolloWsKeepAlive)
+
+        then:
+        thrown(NoSuchBeanException)
 
         cleanup:
         context.close()

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/apollo/ws/GraphQLApolloWsConfigurationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/apollo/ws/GraphQLApolloWsConfigurationSpec.groovy
@@ -122,11 +122,8 @@ class GraphQLApolloWsConfigurationSpec extends Specification {
         ))
         context.start()
 
-        when:
-        context.getBean(GraphQLApolloWsKeepAlive)
-
-        then:
-        thrown(NoSuchBeanException)
+        expect:
+        !context.containsBean(GraphQLApolloWsKeepAlive)
 
         cleanup:
         context.close()


### PR DESCRIPTION
GraphQLApolloWsKeepAlive class didn't contain `GraphQLConfiguration.PREFIX` in `@Requires` annotation, so GraphQLApolloWsKeepAlive bean was created even when `keep-alive-enabled: false`