### PR TITLE
Implementation of current graphql-ws protocol.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 micronaut-docs = "2.0.0"
 micronaut = "4.0.0-RC1"
-micronaut-platform = "4.0.0-M3"
+micronaut-platform = "4.0.0-M4"
 micronaut-test = "4.0.0-M7"
 groovy = "4.0.12"
 spock = "2.3-groovy-4.0"

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphiQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphiQLController.java
@@ -15,7 +15,7 @@
  */
 package io.micronaut.configuration.graphql;
 
-import io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsConfiguration;
+import io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsConfiguration;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.DefaultPropertyPlaceholderResolver;
 import io.micronaut.context.env.PropertyPlaceholderResolver;
@@ -60,7 +60,6 @@ public class GraphiQLController {
     private final GraphQLApolloWsConfiguration graphQLApolloWsConfiguration;
     private final ResourceResolver resourceResolver;
     private final ConversionService conversionService;
-
     private final String rawTemplate;
     private final Supplier<String> resolvedTemplate;
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsConfiguration.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql.ws;
+
+import io.micronaut.configuration.graphql.GraphQLConfiguration;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.util.Toggleable;
+
+import java.time.Duration;
+
+/**
+ * Configuration of the graphql-ws protocol support.
+ *
+ * @author Jeremy Grelle
+ * @since 4.0
+ */
+@ConfigurationProperties(GraphQLConfiguration.PREFIX + "." + GraphQLWsConfiguration.PREFIX)
+public class GraphQLWsConfiguration implements Toggleable {
+
+    /**
+     * The prefix to use for all GraphQL websocket configuration properties.
+     */
+    public static final String PREFIX = "graphql-ws";
+
+    /**
+     * The configuration name whether the GraphQL websocket is enabled.
+     */
+    public static final String ENABLED = GraphQLConfiguration.PREFIX + "." + PREFIX + ".enabled";
+
+    /**
+     * The default enabled value.
+     */
+    public static final boolean DEFAULT_ENABLED = false;
+
+    /**
+     * The configuration name of the GraphQL websocket path.
+     */
+    public static final String PATH = PREFIX + ".path";
+
+    /**
+     * The configuration name of the GraphQL websocket connection initialisation wait timeout.
+     */
+    public static final String CONNECTION_TIMEOUT = PREFIX + ".connection-init-wait-timeout";
+
+    /**
+     * The default GraphQL websocket path.
+     */
+    public static final String DEFAULT_PATH = "/graphql-ws";
+
+    /**
+     * The default connection initialisation wait timeout.
+     */
+    public static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(15L);
+
+    protected boolean enabled = DEFAULT_ENABLED;
+
+    protected String path = DEFAULT_PATH;
+
+    protected Duration connectionInitWaitTimeout = DEFAULT_CONNECTION_TIMEOUT;
+
+
+    /**
+     * Returns whether GraphQL websocket is enabled.
+     *
+     * @return whether GraphQL websocket is enabled
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Returns the GraphQL websocket path.
+     *
+     * @return the GraphQL websocket path
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * Returns the connection intialisation wait timeout.
+     *
+     * @return the connection intialisation wait timeout
+     */
+    public Duration getConnectionInitWaitTimeout() {
+        return connectionInitWaitTimeout;
+    }
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsHandler.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsHandler.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql.ws;
+
+import graphql.ExecutionResult;
+import io.micronaut.configuration.graphql.GraphQLConfiguration;
+import io.micronaut.configuration.graphql.GraphQLInvocation;
+import io.micronaut.configuration.graphql.GraphQLInvocationData;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.codec.CodecException;
+import io.micronaut.scheduling.ScheduledExecutorTaskScheduler;
+import io.micronaut.websocket.CloseReason;
+import io.micronaut.websocket.WebSocketSession;
+import io.micronaut.websocket.annotation.*;
+import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+
+/**
+ * WebSocket request handler for the graphql-ws protocol. Supports the 'graphql-transport-ws' WebSocket subprotocol.
+ *
+ * @author Jeremy Grelle
+ * @since 4.0
+ */
+@ServerWebSocket(value = "${" + GraphQLConfiguration.PREFIX + "." + GraphQLWsConfiguration.PATH + ":"
+    + GraphQLWsConfiguration.DEFAULT_PATH + "}", subprotocols = "graphql-transport-ws")
+@Requires(property = GraphQLWsConfiguration.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
+public class GraphQLWsHandler {
+
+    static final String HTTP_REQUEST_KEY = "httpRequest";
+
+    private static final Logger LOG = LoggerFactory.getLogger(GraphQLWsHandler.class);
+
+    private final ScheduledExecutorTaskScheduler scheduler;
+
+    private final GraphQLInvocation graphQLInvocation;
+
+    private final GraphQLWsConfiguration configuration;
+
+    private final ConcurrentSkipListSet<String> connections = new ConcurrentSkipListSet<>();
+
+    private final ConcurrentMap<String, Publisher<? extends Message>> subscriptions = new ConcurrentHashMap<>();
+
+    /**
+     * Constructor for the graphql-ws WebSocket handler.
+     *
+     * @param scheduler The task scheduler for handling connection initialisation timeouts.
+     * @param graphQLInvocation The graphql invocation helper for executing GraphQL operations.
+     * @param configuration The configuration of the graphql-ws support.
+     */
+    public GraphQLWsHandler(ScheduledExecutorTaskScheduler scheduler, GraphQLInvocation graphQLInvocation, GraphQLWsConfiguration configuration) {
+        this.scheduler = scheduler;
+        this.graphQLInvocation = graphQLInvocation;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Called when the connection is opened. We store the original request, since it might be needed for the
+     * GraphQLInvocation.
+     *
+     * @param session WebSocketSession
+     * @param request HttpRequest
+     */
+    @OnOpen
+    @SuppressWarnings("rawtypes")
+    public void onOpen(WebSocketSession session, HttpRequest request) {
+        session.put(HTTP_REQUEST_KEY, request);
+        scheduler.schedule(configuration.getConnectionInitWaitTimeout(), () -> {
+            if (!connections.contains(session.getId())) {
+                session.close(new CloseReason(4408, "Connection initialisation timeout."));
+            }
+        });
+        LOG.trace("Opened websocket connection with id {}", session.getId());
+    }
+
+
+    /**
+     * Called on every message received from the client.
+     *
+     * @param message Message received from a client
+     * @param session WebSocketSession
+     * @return {@code Publisher<Message>}
+     */
+    @OnMessage
+    public Publisher<? extends Message> onMessage(
+        Message message,
+        WebSocketSession session) {
+        if (message instanceof ConnectionInitMessage) {
+            LOG.trace("Received connection initialisation request for session id {}", session.getId());
+            return connections.add(session.getId()) ? session.send(new ConnectionAckMessage()) : tooManyInitialisationRequests(session);
+        } else if (message instanceof PingMessage) {
+            LOG.trace("Received a ping message for session id {}", session.getId());
+            return session.send(new PongMessage());
+        } else if (message instanceof SubscribeMessage m) {
+            LOG.trace("Received subscription message for session id {}", session.getId());
+            if (!connections.contains(session.getId())) {
+                return unauthorized(session);
+            }
+            if (subscriptions.containsKey(m.getId())) {
+                return subscriberAlreadyExists(m.getId(), session);
+            }
+            Publisher<? extends Message> subscription = executeSubscribe(m, session).doFinally(s -> subscriptions.remove(m.getId()));
+            subscriptions.put(m.getId(), subscription);
+            return subscription;
+        } else if (message instanceof CompleteMessage m) {
+            LOG.trace("Received complete message for session id {}", session.getId());
+            subscriptions.remove(m.getId());
+        }
+        return Mono.empty();
+    }
+
+    @SuppressWarnings({"rawtypes"})
+    private Mono<? extends Message> executeSubscribe(SubscribeMessage subscribeMessage, WebSocketSession session) {
+        GraphQLInvocationData invocationData = new GraphQLInvocationData(subscribeMessage.getSubscribePayload().getQuery(),
+            subscribeMessage.getSubscribePayload().getOperationName(), subscribeMessage.getSubscribePayload().getVariables());
+
+        Optional<HttpRequest> httpRequest = session.get(HTTP_REQUEST_KEY, HttpRequest.class);
+        if (httpRequest.isEmpty()) {
+            return Mono.error(new IllegalStateException("The HTTP request from the original WebSocket connection could not be retrieved."));
+        }
+
+        return Flux.from(graphQLInvocation.invoke(invocationData, httpRequest.get(), null))
+            .flatMap(executionResult -> {
+                if (executionResult.isDataPresent() && executionResult.getData() != null && executionResult.getData() instanceof Publisher<?> p) {
+                    return Flux.from(p).map(o -> {
+                        if (o instanceof ExecutionResult publishedExecutionResult) {
+                            return publishedExecutionResult;
+                        }
+                        throw new IllegalArgumentException("Subscription data is an invalid type " + o.getClass().getName() + "- expected to be an ExecutionResult");
+                    });
+                }
+                return Flux.just(executionResult);
+            })
+            .takeUntil(e -> !subscriptions.containsKey(subscribeMessage.getId()))
+            .flatMap(executionResult -> {
+                if (!session.isOpen() && subscriptions.containsKey(subscribeMessage.getId())) {
+                    return Mono.empty();
+                }
+                if (executionResult.getErrors().isEmpty()) {
+                    return session.send((Message) new NextMessage(subscribeMessage.getId(), executionResult));
+                }
+                return session.send((Message) ErrorMessage.of(subscribeMessage.getId(), executionResult.getErrors()));
+            })
+            .last()
+            .filter(finalResponseMessage -> finalResponseMessage instanceof NextMessage)
+            .flatMap(m -> Mono.from(session.isOpen() && subscriptions.containsKey(subscribeMessage.getId())
+                ? session.send(new CompleteMessage(subscribeMessage.getId())) : Mono.empty()));
+    }
+
+    private Publisher<? extends Message> unauthorized(WebSocketSession session) {
+        session.close(new CloseReason(4401, "Unauthorized."));
+        return Mono.empty();
+    }
+
+    private Publisher<? extends Message> tooManyInitialisationRequests(WebSocketSession session) {
+        session.close(new CloseReason(4403, "Too many initialisation requests."));
+        return Mono.empty();
+    }
+
+    private Publisher<? extends Message> subscriberAlreadyExists(String id, WebSocketSession session) {
+        session.close(new CloseReason(4409, "Subscriber for " + id + " already exists."));
+        return Mono.empty();
+    }
+
+    /**
+     * Called when the websocket is closed.
+     *
+     * @param session     The {@link WebSocketSession} being closed.
+     * @param closeReason The {@link CloseReason} describing why the socket has been closed.
+     */
+    @OnClose
+    public void onClose(WebSocketSession session, CloseReason closeReason) {
+        LOG.trace("Closed websocket connection with id {} with reason {}", session.getId(), closeReason);
+    }
+
+    /**
+     * Called when there is an error with the websocket. If a JSON decoding error is detected, the socket will be closed
+     * with a <code>4400</code> error as defined by the graphql-ws spec.
+     *
+     * @param session The {@link WebSocketSession} where an error occurred.
+     * @param t       {@link Throwable}, the cause of the error
+     */
+    @OnError
+    public void onError(WebSocketSession session, Throwable t) {
+        LOG.debug("Error websocket connection with id {} with error {}", session.getId(), t.getMessage());
+        if (t instanceof CodecException) {
+            session.close(new CloseReason(4400, "Invalid message."));
+        }
+    }
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/Message.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/Message.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql.ws;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import graphql.ExecutionResult;
+import graphql.GraphQLError;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+/**
+ * A class for mapping graphql-ws messages.
+ *
+ * @author Jeremy Grelle
+ * @since 4.0
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @Type(value = ConnectionInitMessage.class, name = Message.Types.CONNECTION_INIT),
+    @Type(value = ConnectionAckMessage.class, name = Message.Types.CONNECTION_ACK),
+    @Type(value = PingMessage.class, name = Message.Types.PING),
+    @Type(value = PongMessage.class, name = Message.Types.PONG),
+    @Type(value = SubscribeMessage.class, name = Message.Types.SUBSCRIBE),
+    @Type(value = NextMessage.class, name = Message.Types.NEXT),
+    @Type(value = ErrorMessage.class, name = Message.Types.ERROR),
+    @Type(value = CompleteMessage.class, name = Message.Types.COMPLETE)
+})
+public abstract sealed class Message {
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @JsonIgnore
+    @NonNull
+    abstract String getMessageType();
+
+    /**
+     * The allowable graphql-ws message types.
+     */
+    public static class Types {
+        public static final String CONNECTION_INIT = "connection_init";
+        public static final String CONNECTION_ACK = "connection_ack";
+        public static final String PING = "ping";
+        public static final String PONG = "pong";
+        public static final String SUBSCRIBE = "subscribe";
+        public static final String NEXT = "next";
+        public static final String ERROR = "error";
+        public static final String COMPLETE = "complete";
+    }
+}
+
+/**
+ * A graphql-ws message that contains an optional payload.
+ *
+ * @param <T> The payload type
+ */
+abstract sealed class PayloadMessage<T> extends Message {
+
+    @Nullable
+    private final T payload;
+
+    /**
+     * Default constructor for a graphql-ws message with an optional payload.
+     */
+    public PayloadMessage() {
+        this(null);
+    }
+
+    /**
+     * Constructor for a graphql-ws message with a payload.
+     *
+     * @param payload The message payload.
+     */
+    public PayloadMessage(@Nullable T payload) {
+        this.payload = payload;
+    }
+
+    /**
+     * Get the message payload.
+     *
+     * @return The message payload.
+     */
+    @Nullable
+    public T getPayload() {
+        return payload;
+    }
+}
+
+/**
+ * A graphql-ws message that has a required non-null payload.
+ *
+ * @param <T> The payload type.
+ */
+abstract sealed class RequiredPayloadMessage<T> extends Message {
+
+    @NonNull
+    private final T payload;
+
+    /**
+     * Constructor for a graphql-ws message with a required payload.
+     *
+     * @param payload The message payload.
+     */
+    public RequiredPayloadMessage(@NonNull T payload) {
+        Objects.requireNonNull(payload, "A payload is required for message type '" + getMessageType() + ".");
+        this.payload = payload;
+    }
+
+    /**
+     * Get the message payload - will never be <code>null</code>.
+     *
+     * @return The message payload.
+     */
+    @NonNull
+    public T getPayload() {
+        return payload;
+    }
+}
+
+/**
+ * A graphql-ws message for connection initialisation.
+ */
+final class ConnectionInitMessage extends PayloadMessage<Map<String, Object>> {
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.CONNECTION_INIT;
+    }
+}
+
+/**
+ * A graphql-ws message for connection acknowledgement.
+ */
+final class ConnectionAckMessage extends PayloadMessage<Map<String, Object>> {
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.CONNECTION_ACK;
+    }
+}
+
+/**
+ * A graphql-ws message for a ping.
+ */
+final class PingMessage extends PayloadMessage<Map<String, Object>> {
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.PING;
+    }
+}
+
+/**
+ * A graphql-ws message for a pong.
+ */
+final class PongMessage extends PayloadMessage<Map<String, Object>> {
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.PONG;
+    }
+}
+
+/**
+ * A graphql-ws message for encoding the 'next' result from an executed operation.
+ */
+final class NextMessage extends RequiredPayloadMessage<Map<String, Object>> {
+
+    @NonNull
+    private final String id;
+
+    /**
+     * Constructor for a graphql-ws 'next' message.
+     *
+     * @param id      The required non-empty id of the message.
+     * @param payload The required non-null payload of the message.
+     */
+    @JsonCreator
+    public NextMessage(@NonNull @JsonProperty("id") String id, @NonNull @JsonProperty("payload") Map<String, Object> payload) {
+        super(payload);
+        if (StringUtils.isEmpty(id)) {
+            throw new IllegalArgumentException("'id' is required for messages with type '" + getMessageType() + "'.");
+        }
+        this.id = id;
+    }
+
+    /**
+     * Constructor for a graphql-ws 'next' message.
+     *
+     * @param id      The required non-empty id of the message.
+     * @param payload The required non-null payload of the message.
+     */
+    public NextMessage(@NonNull String id, @NonNull ExecutionResult payload) {
+        this(id, payload.toSpecification());
+    }
+
+    /**
+     * Get the required non-empty message id.
+     *
+     * @return The message id.
+     */
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.NEXT;
+    }
+}
+
+/**
+ * A graphql-ws message for subscribing to the execution of a query.
+ */
+final class SubscribeMessage extends RequiredPayloadMessage<Map<String, Object>> {
+    //TODO - this should be a RequiredPayloadMessage<SubscribeMessage.SubscribePayload>, but Micronaut fails on JSON serialization with a BeanIntrospection error
+    @NonNull
+    private final String id;
+
+    /**
+     * Constructor for a graphql-ws 'subscribe' message.
+     *
+     * @param id
+     * @param payload
+     */
+    @JsonCreator
+    public SubscribeMessage(@NonNull @JsonProperty("id") String id, @NonNull @JsonProperty("payload") SubscribePayload payload) {
+        super(payload.toMap());
+        if (StringUtils.isEmpty(id)) {
+            throw new IllegalArgumentException("'id' is required for messages with type '" + getMessageType() + "'.");
+        }
+        this.id = id;
+    }
+
+    /**
+     * Get the required non-empty message id.
+     *
+     * @return The message id.
+     */
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.SUBSCRIBE;
+    }
+
+    /**
+     * Get the message payload as a {@link SubscribePayload}.
+     *
+     * @return The message payload.
+     */
+    @JsonIgnore
+    @NonNull
+    SubscribePayload getSubscribePayload() {
+        return SubscribePayload.fromMap(getPayload());
+    }
+
+    public static class SubscribePayload {
+
+        @NonNull
+        private final String query;
+
+        @Nullable
+        private String operationName;
+
+        @Nullable
+        private Map<String, Object> variables;
+
+        @Nullable
+        private Map<String, Object> extensions;
+
+        /**
+         * Constructor for a graphql-ws 'subscribe' message's payload.
+         *
+         * @param query The required non-empty query being executed and subscribed.
+         */
+        @JsonCreator
+        public SubscribePayload(@NonNull @JsonProperty("query") String query) {
+            if (StringUtils.isEmpty(query)) {
+                throw new IllegalArgumentException("The 'query' field is required in the payload of message type '" + Types.SUBSCRIBE + "'");
+            }
+            this.query = query;
+        }
+
+        private SubscribePayload(@NonNull String query, @Nullable String operationName, @Nullable Map<String, Object> variables, @Nullable Map<String, Object> extensions) {
+            this.query = query;
+            this.operationName = operationName;
+            this.variables = variables;
+            this.extensions = extensions;
+        }
+
+        /**
+         * Gets the required non-empty query field of the message payload.
+         *
+         * @return The query.
+         */
+        @NonNull
+        public String getQuery() {
+            return query;
+        }
+
+        /**
+         * Gets the operation name of the payload.
+         *
+         * @return The operation name.
+         */
+        @Nullable
+        public String getOperationName() {
+            return operationName;
+        }
+
+        /**
+         * Sets the operation name of the payload.
+         *
+         * @param operationName The operation name.
+         */
+        public void setOperationName(@Nullable String operationName) {
+            this.operationName = operationName;
+        }
+
+        /**
+         * Gets the variables of the payload.
+         *
+         * @return The payload variables.
+         */
+        @Nullable
+        public Map<String, Object> getVariables() {
+            return variables;
+        }
+
+        /**
+         * Sets the variables of the payload.
+         *
+         * @param variables The operation name.
+         */
+        public void setVariables(@Nullable Map<String, Object> variables) {
+            this.variables = variables;
+        }
+
+        /**
+         * Gets the extensions of the payload.
+         *
+         * @return The extensions.
+         */
+        @Nullable
+        public Map<String, Object> getExtensions() {
+            return extensions;
+        }
+
+        /**
+         * Sets the extensions of the payload.
+         *
+         * @param extensions The operation name.
+         */
+        public void setExtensions(@Nullable Map<String, Object> extensions) {
+            this.extensions = extensions;
+        }
+
+        public Map<String, Object> toMap() {
+            return Map.of(
+                "query", this.query,
+                "operationName", Optional.ofNullable(this.operationName).orElse(""),
+                "variables", Optional.ofNullable(this.variables).orElse(new HashMap<>()),
+                "extensions", Optional.ofNullable(this.extensions).orElse(new HashMap<>())
+            );
+        }
+
+        @SuppressWarnings("unchecked")
+        public static SubscribePayload fromMap(Map<String, Object> payload) {
+            return new SubscribePayload(
+                (String) payload.get("query"),
+                (String) payload.get("operationName"),
+                (Map<String, Object>) payload.get("variables"),
+                (Map<String, Object>) payload.get("extensions"));
+        }
+    }
+}
+
+/**
+ * A graphql-ws message for reporting errors pertaining to a specific subscription.
+ */
+final class ErrorMessage extends RequiredPayloadMessage<List<Map<String, Object>>> {
+
+    @NonNull
+    private final String id;
+
+    /**
+     * Constructor for a graphql-ws 'error' message.
+     *
+     * @param id     The required non-empty id of the message.
+     * @param errors The errors resulting from the specific subscription with the corresponding id.
+     */
+    @JsonCreator
+    public ErrorMessage(@NonNull @JsonProperty("id") String id, @NonNull @JsonProperty("payload") List<Map<String, Object>> errors) {
+        super(errors);
+        if (StringUtils.isEmpty(id)) {
+            throw new IllegalArgumentException("'id' is required for messages with type '" + getMessageType() + "'.");
+        }
+        this.id = id;
+    }
+
+    /**
+     * Factory method for a graphql-ws 'error' message.
+     *
+     * @param id     The required non-empty id of the message.
+     * @param errors The errors resulting from the specific subscription with the corresponding id.
+     * @return A new error message.
+     */
+    public static ErrorMessage of(@NonNull String id, @NonNull List<GraphQLError> errors) {
+        return new ErrorMessage(id, errors.stream().map(GraphQLError::toSpecification).collect(Collectors.toList()));
+    }
+
+    /**
+     * Get the required non-empty message id.
+     *
+     * @return The message id.
+     */
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.ERROR;
+    }
+}
+
+/**
+ * A graphql-ws message for the completion of a subscription.
+ */
+final class CompleteMessage extends Message {
+
+    @NonNull
+    private final String id;
+
+    /**
+     * Constructor for a graphql-ws 'complete' message.
+     *
+     * @param id The required non-empty id of the message.
+     */
+    public CompleteMessage(@NonNull String id) {
+        if (StringUtils.isEmpty(id)) {
+            throw new IllegalArgumentException("'id' is required for messages with type '" + getMessageType() + "'.");
+        }
+        this.id = id;
+    }
+
+    /**
+     * Get the required non-empty message id.
+     *
+     * @return The message id.
+     */
+    @NonNull
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get the required value of the message's <code>type</code> field.
+     *
+     * @return The message's type
+     */
+    @Override
+    @JsonIgnore
+    @NonNull
+    String getMessageType() {
+        return Types.COMPLETE;
+    }
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/RequiresGraphQLWs.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/RequiresGraphQLWs.java
@@ -13,28 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws;
 
 import graphql.GraphQL;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Meta annotation for GraphQL web socket requirements.
  *
- * @author Gerard Klijs
- * @since 1.3
+ * @author Jeremy Grelle
+ * @since 4.0
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PACKAGE, ElementType.TYPE})
-@Requires(property = GraphQLApolloWsConfiguration.ENABLED, notEquals = StringUtils.FALSE)
+@Requires(property = GraphQLWsConfiguration.ENABLED, notEquals = StringUtils.FALSE)
 @Requires(beans = GraphQL.class)
-public @interface RequiresGraphQLApolloWs {
+public @interface RequiresGraphQLWs {
 }

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsConfiguration.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsConfiguration.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.configuration.graphql.GraphQLConfiguration;
 import io.micronaut.context.annotation.ConfigurationProperties;
@@ -24,7 +24,9 @@ import io.micronaut.core.util.Toggleable;
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @ConfigurationProperties(GraphQLConfiguration.PREFIX + "." + GraphQLApolloWsConfiguration.PREFIX)
 public class GraphQLApolloWsConfiguration implements Toggleable {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsController.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.configuration.graphql.GraphQLConfiguration;
 import io.micronaut.configuration.graphql.GraphQLJsonSerializer;
@@ -23,17 +23,13 @@ import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.websocket.CloseReason;
 import io.micronaut.websocket.WebSocketSession;
-import io.micronaut.websocket.annotation.OnClose;
-import io.micronaut.websocket.annotation.OnError;
-import io.micronaut.websocket.annotation.OnMessage;
-import io.micronaut.websocket.annotation.OnOpen;
-import io.micronaut.websocket.annotation.ServerWebSocket;
+import io.micronaut.websocket.annotation.*;
 import org.reactivestreams.Publisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_ERROR;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_ERROR;
 
 /**
  * The GraphQL websocket controller handling GraphQL requests.
@@ -41,9 +37,11 @@ import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsRespon
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @ServerWebSocket(value = "${" + GraphQLConfiguration.PREFIX + "." + GraphQLApolloWsConfiguration.PATH + ":"
-        + GraphQLApolloWsConfiguration.DEFAULT_PATH + "}", subprotocols = "graphql-apollo-ws")
+        + GraphQLApolloWsConfiguration.DEFAULT_PATH + "}", subprotocols = "graphql-ws")
 @Requires(property = GraphQLApolloWsConfiguration.ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.FALSE)
 public class GraphQLApolloWsController {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsKeepAlive.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsKeepAlive.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.configuration.graphql.GraphQLConfiguration;
 import io.micronaut.configuration.graphql.GraphQLJsonSerializer;
@@ -23,16 +23,18 @@ import io.micronaut.scheduling.annotation.Scheduled;
 import io.micronaut.websocket.WebSocketBroadcaster;
 import jakarta.inject.Singleton;
 
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_KEEP_ALIVE;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_KEEP_ALIVE;
 
 /**
  * Used to send keep alive messages to the active sessions at a regular interval.
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Singleton
-@Requires(property = GraphQLApolloWsConfiguration.KEEP_ALIVE_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
+@Requires(property = GraphQLConfiguration.PREFIX + "." + GraphQLApolloWsConfiguration.KEEP_ALIVE_ENABLED, value = StringUtils.TRUE, defaultValue = StringUtils.TRUE)
 public class GraphQLApolloWsKeepAlive {
 
     private final WebSocketBroadcaster broadcaster;

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsMessageHandler.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsMessageHandler.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import graphql.ExecutionResult;
 import io.micronaut.configuration.graphql.GraphQLExecutionResultHandler;
@@ -30,17 +30,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.core.publisher.Flux;
 
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsController.HTTP_REQUEST_KEY;
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_ACK;
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_KEEP_ALIVE;
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_ERROR;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsController.HTTP_REQUEST_KEY;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_ACK;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_CONNECTION_KEEP_ALIVE;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_ERROR;
 
 /**
  * Handles the messages send over the websocket.
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Singleton
 public class GraphQLApolloWsMessageHandler {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsOperations.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsOperations.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import jakarta.inject.Singleton;
 import org.reactivestreams.Subscription;
@@ -27,7 +27,9 @@ import java.util.function.Function;
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Singleton
 class GraphQLApolloWsOperations {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsRequest.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsRequest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.configuration.graphql.GraphQLRequestBody;
 import io.micronaut.core.annotation.Nullable;
@@ -23,7 +23,9 @@ import io.micronaut.core.annotation.Nullable;
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 public class GraphQLApolloWsRequest {
 
     private static final String TYPE_ERROR_MESSAGE = "Could not map %s to a known client type.";

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsResponse.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsResponse.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.configuration.graphql.GraphQLResponseBody;
 import io.micronaut.core.annotation.Nullable;
@@ -24,7 +24,9 @@ import io.micronaut.serde.annotation.Serdeable;
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Serdeable
 public class GraphQLApolloWsResponse {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSender.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSender.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import graphql.ExecutionResult;
 import io.micronaut.configuration.graphql.GraphQLJsonSerializer;
@@ -30,16 +30,18 @@ import reactor.core.publisher.Flux;
 import java.util.Collection;
 import java.util.function.Function;
 
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_COMPLETE;
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_DATA;
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_ERROR;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_COMPLETE;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_DATA;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_ERROR;
 
 /**
  * Sends the GraphQL response(s) to the client.
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Singleton
 public class GraphQLApolloWsSender {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsState.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsState.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.websocket.WebSocketSession;
 import jakarta.inject.Singleton;
@@ -26,14 +26,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Function;
 
-import static io.micronaut.configuration.graphql.apollo.ws.GraphQLApolloWsResponse.ServerType.GQL_COMPLETE;
+import static io.micronaut.configuration.graphql.ws.apollo.GraphQLApolloWsResponse.ServerType.GQL_COMPLETE;
 
 /**
  * Keeps the state of the web socket subscriptions.
  *
  * @author Gerard Klijs
  * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Singleton
 class GraphQLApolloWsState {
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/RequiresGraphQLApolloWs.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/RequiresGraphQLApolloWs.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql.ws.apollo;
+
+import graphql.GraphQL;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation for GraphQL web socket requirements.
+ *
+ * @author Gerard Klijs
+ * @since 1.3
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
+ */
+@Deprecated(since = "4.0")
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PACKAGE, ElementType.TYPE})
+@Requires(property = GraphQLApolloWsConfiguration.ENABLED, notEquals = StringUtils.FALSE)
+@Requires(beans = GraphQL.class)
+public @interface RequiresGraphQLApolloWs {
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/package-info.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/apollo/package-info.java
@@ -18,9 +18,11 @@
  *
  * @author Gerard Klijs
  * @since 1.0
+ * @deprecated The Apollo subscriptions-transport-ws protocol is deprecated and its usage should be replaced with the new graphql-ws implementation.
  */
+@Deprecated(since = "4.0")
 @Configuration
 @RequiresGraphQLApolloWs
-package io.micronaut.configuration.graphql.apollo.ws;
+package io.micronaut.configuration.graphql.ws.apollo;
 
 import io.micronaut.context.annotation.Configuration;

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/package-info.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Micronaut GraphQL web socket integration.
+ *
+ * @author Jeremy Grelle
+ * @since 4.0
+ */
+@Configuration
+@RequiresGraphQLWs
+package io.micronaut.configuration.graphql.ws;
+
+import io.micronaut.context.annotation.Configuration;

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsClient.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsClient.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.configuration.graphql.ws
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.websocket.CloseReason
+import io.micronaut.websocket.annotation.ClientWebSocket
+import io.micronaut.websocket.annotation.OnClose
+import io.micronaut.websocket.annotation.OnMessage
+
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.TimeUnit
+
+@Requires(property = "spec.name", value = "GraphQLWsHandlerSpec")
+@ClientWebSocket(uri = "\${graphql.graphql-ws.path:/graphql-ws}", subprotocol = "graphql-transport-ws")
+abstract class GraphQLWsClient implements AutoCloseable {
+
+    private BlockingQueue<Message> responses = new ArrayBlockingQueue<>(10)
+
+    boolean closed = false;
+    CloseReason closeReason = null;
+
+    @OnMessage
+    void onMessage(Message message) {
+        responses.add(message);
+    }
+
+    @OnClose
+    void onClose(CloseReason reason) {
+        closed = true
+        closeReason = reason
+    }
+
+    abstract void send(Object message);
+
+    Message nextResponse() {
+        Message response = responses.poll(2, TimeUnit.SECONDS)
+        return response
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsConfigurationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsConfigurationSpec.groovy
@@ -1,0 +1,103 @@
+package io.micronaut.configuration.graphql.ws
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.DefaultApplicationContext
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySource
+import io.micronaut.websocket.annotation.ServerWebSocket
+import spock.lang.Specification
+
+import java.time.Duration
+
+class GraphQLWsConfigurationSpec extends Specification {
+
+    void "test graphql websocket disabled by default"() {
+        given:
+        ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
+        context.start()
+
+        expect:
+        !context.containsBean(GraphQLWsHandler)
+
+        cleanup:
+        context.close()
+    }
+
+    void "test graphql websocket enabled"() {
+        given:
+        ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
+        context.environment.addPropertySource(PropertySource.of(
+                ["graphql.graphql-ws.enabled": true]
+        ))
+        context.start()
+
+        expect:
+        context.containsBean(GraphQLWsHandler)
+        context.getBeanDefinition(GraphQLWsHandler).getAnnotation(ServerWebSocket).getRequiredValue(String) == "/graphql-ws"
+        GraphQLWsConfiguration graphQLWsConfiguration = context.getBean(GraphQLWsConfiguration)
+        graphQLWsConfiguration.path == "/graphql-ws"
+
+        and:
+        graphQLWsConfiguration.enabled
+        graphQLWsConfiguration.connectionInitWaitTimeout == Duration.ofSeconds(15L)
+
+        cleanup:
+        context.close()
+    }
+
+    void "test graphql websocket enabled with custom connection timeout"() {
+        given:
+        ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
+        context.environment.addPropertySource(PropertySource.of(
+                ["graphql.graphql-ws.enabled"                     : true,
+                 "graphql.graphql-ws.connection-init-wait-timeout": "30s"]
+        ))
+        context.start()
+
+        expect:
+        context.containsBean(GraphQLWsHandler)
+        context.getBeanDefinition(GraphQLWsHandler).getAnnotation(ServerWebSocket).getRequiredValue(String) == "/graphql-ws"
+        GraphQLWsConfiguration graphQLWsConfiguration = context.getBean(GraphQLWsConfiguration)
+        graphQLWsConfiguration.path == "/graphql-ws"
+
+        and:
+        graphQLWsConfiguration.enabled
+        graphQLWsConfiguration.connectionInitWaitTimeout == Duration.ofSeconds(30L)
+
+        cleanup:
+        context.close()
+    }
+    void "test custom path"() {
+        given:
+        ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
+        context.environment.addPropertySource(PropertySource.of(
+                ["graphql.graphql-ws.enabled": true,
+                 "graphql.graphql-ws.path"   : "/custom-graphql-ws"]
+        ))
+        context.start()
+
+        expect:
+        context.containsBean(GraphQLWsHandler)
+        context.getBeanDefinition(GraphQLWsHandler).getAnnotation(ServerWebSocket).getRequiredValue(String) == "/custom-graphql-ws"
+        context.getBean(GraphQLWsConfiguration).path == "/custom-graphql-ws"
+
+        cleanup:
+        context.close()
+    }
+
+    void "test graphql websocket disabled"() {
+        given:
+        ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
+        context.environment.addPropertySource(PropertySource.of(
+                ["graphql.graphql-ws.enabled": false]
+        ))
+        context.start()
+
+        expect:
+        !context.containsBean(GraphQLWsHandler)
+
+        cleanup:
+        context.close()
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsHandlerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsHandlerSpec.groovy
@@ -1,0 +1,291 @@
+package io.micronaut.configuration.graphql.ws
+
+import graphql.ExecutionInput
+import io.micronaut.configuration.graphql.GraphQLExecutionInputCustomizer
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.async.publisher.Publishers
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.websocket.WebSocketClient
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class GraphQLWsHandlerSpec extends Specification {
+
+    @AutoCleanup
+    EmbeddedServer embeddedServer
+
+    GraphQLWsClient graphQLWsClient
+
+    def setup() {
+        embeddedServer = ApplicationContext.run(EmbeddedServer, ["spec.name": GraphQLWsHandlerSpec.simpleName], "websocket") as EmbeddedServer
+        WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, embeddedServer.getURI())
+        graphQLWsClient = Flux.from(wsClient.connect(GraphQLWsClient, "/graphql-ws")).blockFirst()
+    }
+
+    void "connection initialization"() {
+        given:
+        Message request = new ConnectionInitMessage();
+
+        when: "a connection is initialized"
+        graphQLWsClient.send(request)
+        Message ack = graphQLWsClient.nextResponse()
+
+        then: "the server responds with an ack"
+        ack instanceof ConnectionAckMessage
+    }
+
+    void "connection initialization timeout"() {
+        when: "no connection is initialized before the configured timeout"
+        Thread.sleep(3000)
+
+        then: "the socket is closed with an error response"
+        graphQLWsClient.nextResponse() == null
+        graphQLWsClient.closed
+        graphQLWsClient.closeReason.getCode() == 4408
+        graphQLWsClient.closeReason.getReason() == "Connection initialisation timeout."
+    }
+
+    void "client sends multiple connection requests"() {
+        given:
+        Message request1 = new ConnectionInitMessage()
+        Message request2 = new ConnectionInitMessage()
+
+        when: "a connection init is received on an already established connection"
+        graphQLWsClient.send(request1)
+        graphQLWsClient.send(request2)
+        Message ack = graphQLWsClient.nextResponse()
+
+        then: "the socket is closed with an error response"
+        ack instanceof ConnectionAckMessage
+        graphQLWsClient.nextResponse() == null
+        graphQLWsClient.closed
+        graphQLWsClient.closeReason.getCode() == 4403
+        graphQLWsClient.closeReason.getReason() == "Too many initialisation requests."
+    }
+
+    void "client sends heartbeat" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message ping = new PingMessage()
+
+        when:
+        graphQLWsClient.send(connect)
+        Message ack = graphQLWsClient.nextResponse()
+
+        then:
+        ack instanceof ConnectionAckMessage
+
+        when: "a heartbeat ping message is received"
+        graphQLWsClient.send(ping)
+        Message pong = graphQLWsClient.nextResponse()
+
+        then: "a heartbeat pong message is sent in response"
+        pong instanceof PongMessage
+    }
+
+    void "client subscribes to a single-result query operation and receives result" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe = new SubscribeMessage("query_id", new SubscribeMessage.SubscribePayload("query{ foo }"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe)
+        Message nextResult = graphQLWsClient.nextResponse()
+        Message completeResult = graphQLWsClient.nextResponse()
+
+        then:
+        nextResult != null && nextResult instanceof NextMessage && nextResult.getPayload().get("data") == [foo: "bar"]
+        completeResult != null && completeResult instanceof CompleteMessage && "query_id" == completeResult.getId()
+    }
+
+    void "client subscribes to a mutation operation and receives result" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe = new SubscribeMessage("change_id", new SubscribeMessage.SubscribePayload("mutation{ change( newValue: \"Value_B\" ){ current old }}"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe)
+        Message nextResult = graphQLWsClient.nextResponse()
+        Message completeResult = graphQLWsClient.nextResponse()
+
+        then:
+        nextResult != null && nextResult instanceof NextMessage && nextResult.getPayload().get("data") == [change: [current: "Value_B", old: ["Value_A"]]]
+        completeResult != null && completeResult instanceof CompleteMessage && "change_id" == completeResult.getId()
+    }
+
+    void "client subscribes to a mutation operation that uses a customizer that evaluates the http request and receives result" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe = new SubscribeMessage("change_id", new SubscribeMessage.SubscribePayload("mutation{ change( newValue: \"\$[path]\" ){ current old }}"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe)
+        Message nextResult = graphQLWsClient.nextResponse()
+        Message completeResult = graphQLWsClient.nextResponse()
+
+        then:
+        nextResult != null && nextResult instanceof NextMessage && nextResult.getPayload().get("data") == [change: [current: "/graphql-ws", old: ["Value_A"]]]
+        completeResult != null && completeResult instanceof CompleteMessage && "change_id" == completeResult.getId()
+    }
+
+    void "client subscribes to an operation with invalid query and receives error result" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe = new SubscribeMessage("query_id", new SubscribeMessage.SubscribePayload("foo"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe)
+        Message errorResult = graphQLWsClient.nextResponse()
+
+        then:
+        errorResult != null && errorResult instanceof ErrorMessage && errorResult.getPayload() != null && !errorResult.getPayload().isEmpty() && "query_id" == errorResult.getId()
+        graphQLWsClient.nextResponse() == null
+    }
+
+    void "client subscribes to a long-running subscription operation and receive all results" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe = new SubscribeMessage("counter_id", new SubscribeMessage.SubscribePayload("subscription{ counter }"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe)
+        Message nextResult1 = graphQLWsClient.nextResponse()
+        Message nextResult2 = graphQLWsClient.nextResponse()
+        Message nextResult3 = graphQLWsClient.nextResponse()
+        Message completeResult = graphQLWsClient.nextResponse()
+
+        then:
+        nextResult1 != null && nextResult1 instanceof NextMessage && nextResult1.getPayload().get("data") == [counter: 0]
+        nextResult2 != null && nextResult2 instanceof NextMessage && nextResult2.getPayload().get("data") == [counter: 1]
+        nextResult3 != null && nextResult3 instanceof NextMessage && nextResult3.getPayload().get("data") == [counter: 2]
+        completeResult != null && completeResult instanceof CompleteMessage && "counter_id" == completeResult.getId()
+    }
+
+    void "client subscribes to a long-running subscription operation and completes after 1 result" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe = new SubscribeMessage("counter_id", new SubscribeMessage.SubscribePayload("subscription{ counter }"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe)
+        Message nextResult1 = graphQLWsClient.nextResponse()
+        graphQLWsClient.send(new CompleteMessage("counter_id"))
+        List<Message> responses = new ArrayList<>()
+        while(true) {
+            Message next = graphQLWsClient.nextResponse()
+            if (next == null) {
+                break
+            }
+            responses.add(next)
+        }
+
+        then:
+        nextResult1 != null && nextResult1 instanceof NextMessage && nextResult1.getPayload().get("data") == [counter: 0]
+        responses.stream().noneMatch(message -> message instanceof CompleteMessage)
+    }
+
+    void "reject subscription without a connection" () {
+        given:
+        Message subscribe = new SubscribeMessage("12345", new SubscribeMessage.SubscribePayload("foo"))
+
+        when: "a subscribe message is received without a connection"
+        graphQLWsClient.send(subscribe)
+
+        then: "the socket is closed with a an unauthorized error"
+        graphQLWsClient.nextResponse() == null
+        graphQLWsClient.closed
+        graphQLWsClient.closeReason.getCode() == 4401
+        graphQLWsClient.closeReason.getReason() == "Unauthorized."
+    }
+
+    void "reject duplicate subscriptions" () {
+        given:
+        Message connect = new ConnectionInitMessage()
+        Message subscribe1 = new SubscribeMessage("counter_id", new SubscribeMessage.SubscribePayload("subscription{ counter }"));
+        Message subscribe2 = new SubscribeMessage("counter_id", new SubscribeMessage.SubscribePayload("subscription{ counter }"));
+
+        when:
+        graphQLWsClient.send(connect)
+        graphQLWsClient.nextResponse()
+        graphQLWsClient.send(subscribe1)
+        graphQLWsClient.send(subscribe2)
+        Message response = graphQLWsClient.nextResponse()
+        while(response != null) {
+            response = graphQLWsClient.nextResponse()
+        }
+
+        then: "the socket is closed with a subscriber already exists error"
+        graphQLWsClient.closed
+        graphQLWsClient.closeReason.getCode() == 4409
+        graphQLWsClient.closeReason.getReason() == "Subscriber for counter_id already exists."
+    }
+
+    void "reject invalid message" () {
+        given:
+        Map<String, Object> invalidMessage = Map.of("foo", "bar")
+
+        when:
+        graphQLWsClient.send(invalidMessage)
+        graphQLWsClient.nextResponse()
+
+        then:
+        graphQLWsClient.closed
+        graphQLWsClient.closeReason.getCode() == 4400
+        graphQLWsClient.closeReason.getReason() == "Invalid message."
+
+    }
+
+    void "reject invalid type message" () {
+        given:
+        Map<String, Object> invalidMessage = Map.of("type", "foo", "id", "12345")
+
+        when:
+        graphQLWsClient.send(invalidMessage)
+        graphQLWsClient.nextResponse()
+
+        then:
+        graphQLWsClient.closed
+        graphQLWsClient.closeReason.getCode() == 4400
+        graphQLWsClient.closeReason.getReason() == "Invalid message."
+
+    }
+
+}
+
+@Singleton
+@Primary
+@Requires(property = "spec.name", value = "GraphQLWsHandlerSpec")
+class SetValueFromRequestInputCustomizer implements GraphQLExecutionInputCustomizer {
+    private final static String PATH_PLACEHOLDER = "\$[path]"
+
+    @Override
+    Publisher<ExecutionInput> customize(ExecutionInput executionInput, HttpRequest httpRequest,
+                                        MutableHttpResponse<String> httpResponse) {
+        if (executionInput.getQuery().contains(PATH_PLACEHOLDER)) {
+            return Publishers.just(executionInput.transform({
+                builder -> builder.query(executionInput.getQuery().replace(PATH_PLACEHOLDER, httpRequest.getPath()))
+            }))
+        } else {
+            return Publishers.just(executionInput)
+        }
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsClient.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsClient.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.configuration.graphql.apollo.ws
+package io.micronaut.configuration.graphql.ws.apollo
 
 import io.micronaut.configuration.graphql.GraphQLJsonSerializer
 import io.micronaut.configuration.graphql.GraphQLRequestBody
@@ -13,7 +13,7 @@ import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.TimeUnit
 
-@ClientWebSocket(uri = "\${graphql.graphql-apollo-ws.path:/graphql-ws}", subprotocol = "graphql-apollo-ws")
+@ClientWebSocket(uri = "\${graphql.graphql-apollo-ws.path:/graphql-ws}", subprotocol = "graphql-ws")
 abstract class GraphQLApolloWsClient implements AutoCloseable {
 
     private BlockingQueue<GraphQLApolloWsResponse> responses = new ArrayBlockingQueue<>(10)

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsConfigurationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsConfigurationSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micronaut.configuration.graphql.apollo.ws
+package io.micronaut.configuration.graphql.ws.apollo
 
 
 import io.micronaut.context.ApplicationContext
@@ -23,7 +23,6 @@ import io.micronaut.context.env.Environment
 import io.micronaut.context.env.PropertySource
 import io.micronaut.websocket.annotation.ServerWebSocket
 import spock.lang.Specification
-
 /**
  * @author Gerard Klijs
  * @since 1.3
@@ -65,7 +64,7 @@ class GraphQLApolloWsConfigurationSpec extends Specification {
         context.close()
     }
 
-    void "test custom graphiql path"() {
+    void "test custom path"() {
         given:
         ApplicationContext context = new DefaultApplicationContext(Environment.TEST)
         context.environment.addPropertySource(PropertySource.of(

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsControllerSpec.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.micronaut.configuration.graphql.apollo.ws
+package io.micronaut.configuration.graphql.ws.apollo
 
 import graphql.ExecutionInput
 import io.micronaut.configuration.graphql.GraphQLExecutionInputCustomizer
@@ -32,7 +32,6 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import spock.lang.AutoCleanup
 import spock.lang.Specification
-
 /**
  * @author Gerard Klijs
  * @since 1.3
@@ -45,7 +44,7 @@ class GraphQLApolloWsControllerSpec extends Specification {
     GraphQLApolloWsClient graphQLWsClient
 
     def setup() {
-        embeddedServer = embeddedServer = ApplicationContext.run(EmbeddedServer, ["spec.name": GraphQLApolloWsControllerSpec.simpleName], "websocket") as EmbeddedServer
+        embeddedServer = ApplicationContext.run(EmbeddedServer, ["spec.name": GraphQLApolloWsControllerSpec.simpleName], "apollows") as EmbeddedServer
         WebSocketClient wsClient = embeddedServer.applicationContext.createBean(WebSocketClient, embeddedServer.getURI())
         graphQLWsClient = Flux.from(wsClient.connect(GraphQLApolloWsClient, "/graphql-ws")).blockFirst()
     }

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsFactory.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsFactory.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.configuration.graphql.apollo.ws
+package io.micronaut.configuration.graphql.ws.apollo
 
 import graphql.GraphQL
 import graphql.schema.DataFetcher
@@ -20,7 +20,7 @@ import java.time.Duration
 class GraphQLApolloWsFactory {
 
     @Bean
-    @Requires(env = ["websocket", "keepalive"])
+    @Requires(env = ["websocket", "apollows", "keepalive"])
     GraphQL graphQL() {
         SchemaParser schemaParser = new SchemaParser()
         SchemaGenerator schemaGenerator = new SchemaGenerator()

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsKeepAliveSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsKeepAliveSpec.groovy
@@ -1,4 +1,4 @@
-package io.micronaut.configuration.graphql.apollo.ws
+package io.micronaut.configuration.graphql.ws.apollo
 
 
 import io.micronaut.context.ApplicationContext

--- a/graphql/src/test/resources/application-apollows.yml
+++ b/graphql/src/test/resources/application-apollows.yml
@@ -1,0 +1,5 @@
+graphql:
+  graphql-apollo-ws:
+    enabled: true
+    keep-alive-enabled: false
+  factory: false

--- a/graphql/src/test/resources/application-websocket.yml
+++ b/graphql/src/test/resources/application-websocket.yml
@@ -1,5 +1,5 @@
 graphql:
-  graphql-apollo-ws:
+  graphql-ws:
     enabled: true
-    keep-alive-enabled: false
+    connection-init-wait-timeout: 2s
   factory: false


### PR DESCRIPTION
An implementation of the newer graphql-ws protocol in favor of the now deprecated Apollo implementation.

This implementation complies with the specification at https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md

The previous Apollo protocol implementation has been deprecated and its classes re-arranged.

Resolves issue #301.