### PR TITLE
Fix GraphQL with Jackson

### DIFF
--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -4,13 +4,15 @@ plugins {
 
 dependencies {
     annotationProcessor(mnSerde.micronaut.serde.processor)
-    api(mnSerde.micronaut.serde.jackson)
+
+    compileOnly(mnSerde.micronaut.serde.api)
+    compileOnly(mn.jackson.annotations)
     api(libs.managed.graphql.java)
 
     api(mn.micronaut.http.server)
     api(mn.reactor)
     api(mn.micronaut.websocket)
-
+    testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.jackson.databind)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)

--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     annotationProcessor(mnSerde.micronaut.serde.processor)
-
     compileOnly(mnSerde.micronaut.serde.api)
     compileOnly(mn.jackson.annotations)
     api(libs.managed.graphql.java)
@@ -12,6 +11,7 @@ dependencies {
     api(mn.micronaut.http.server)
     api(mn.reactor)
     api(mn.micronaut.websocket)
+
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.jackson.databind)
     testImplementation(mn.micronaut.http.server.netty)

--- a/graphql/build.gradle
+++ b/graphql/build.gradle
@@ -4,15 +4,13 @@ plugins {
 
 dependencies {
     annotationProcessor(mnSerde.micronaut.serde.processor)
-    compileOnly(mnSerde.micronaut.serde.api)
-    compileOnly(mn.jackson.annotations)
+    api(mnSerde.micronaut.serde.jackson)
     api(libs.managed.graphql.java)
 
     api(mn.micronaut.http.server)
     api(mn.reactor)
     api(mn.micronaut.websocket)
 
-    testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(mn.micronaut.jackson.databind)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.http.client)

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSerializationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSerializationSpec.groovy
@@ -4,6 +4,7 @@ import io.micronaut.configuration.graphql.GraphQLRequestBody
 import io.micronaut.configuration.graphql.GraphQLResponseBody
 import io.micronaut.jackson.databind.JacksonDatabindMapper
 import io.micronaut.json.JsonMapper
+import io.micronaut.serde.jackson.JacksonJsonMapper
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Shared
@@ -14,7 +15,7 @@ class GraphQLApolloWsSerializationSpec extends Specification {
 
     @Shared
     @Inject
-    JsonMapper micronautMapper
+    JacksonJsonMapper micronautMapper
 
     @Shared
     JsonMapper jacksonMapper = new JacksonDatabindMapper();

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSerializationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSerializationSpec.groovy
@@ -15,7 +15,7 @@ class GraphQLApolloWsSerializationSpec extends Specification {
 
     @Shared
     @Inject
-    JsonMapper micronautMapper
+    JacksonJsonMapper micronautMapper
 
     @Shared
     JsonMapper jacksonMapper = new JacksonDatabindMapper();

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSerializationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/apollo/GraphQLApolloWsSerializationSpec.groovy
@@ -15,7 +15,7 @@ class GraphQLApolloWsSerializationSpec extends Specification {
 
     @Shared
     @Inject
-    JacksonJsonMapper micronautMapper
+    JsonMapper micronautMapper
 
     @Shared
     JsonMapper jacksonMapper = new JacksonDatabindMapper();

--- a/src/main/docs/guide/configuration/jackson.adoc
+++ b/src/main/docs/guide/configuration/jackson.adoc
@@ -1,0 +1,9 @@
+If you are using Jackson serialization instead of https://github.com/micronaut-projects/micronaut-serialization/[Micronaut Serialization], you need to configure your application to keep empty and null values in the serialized JSON.
+
+This is done via:
+
+[configuration]
+----
+jackson:
+    serialization-inclusion: ALWAYS
+----

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -7,5 +7,6 @@ configuration:
   graphql-bean: Configuring the GraphQL Bean
   graphql-ws: Configuring GraphQL over websockets
   graphiql: Configuring GraphiQL
+  jackson: Notes on using Jackson serialization
 graphqlGuides: Guides
 repository: Repository

--- a/test-suite-jackson/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
+++ b/test-suite-jackson/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
@@ -18,7 +18,17 @@ class GraphQLJacksonSerializationTest {
     void serializeGraphQLResponseBody(JsonMapper mapper) throws IOException {
         Map<String, Object> specification = Collections.singletonMap("foo", "bar");
         var response = new GraphQLResponseBody(specification);
-        var expected = "{\"foo\":\"bar\"}";
+        var expected = """
+            {"foo":"bar"}""";
+        assertEquals(expected, mapper.writeValueAsString(response));
+    }
+
+    @Test
+    void serializeEmptyGraphQLResponseBody(JsonMapper mapper) throws IOException {
+        Map<String, Object> specification = Collections.singletonMap("foo", Map.of("bar", Collections.emptyList()));
+        var response = new GraphQLResponseBody(specification);
+        var expected = """
+            {"foo":{"bar":[]}}""";
         assertEquals(expected, mapper.writeValueAsString(response));
     }
 }

--- a/test-suite-jackson/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
+++ b/test-suite-jackson/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
@@ -1,6 +1,7 @@
 package example.micronaut;
 
 import io.micronaut.configuration.graphql.GraphQLResponseBody;
+import io.micronaut.context.annotation.Property;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@Property(name = "jackson.serializationInclusion", value = "ALWAYS")
 @MicronautTest
 class GraphQLJacksonSerializationTest {
 

--- a/test-suite-jackson/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
+++ b/test-suite-jackson/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
@@ -16,7 +16,7 @@ class GraphQLJacksonSerializationTest {
 
     @Test
     void serializeGraphQLResponseBody(JsonMapper mapper) throws IOException {
-        Map<String, Object> specification = Collections.singletonMap("foo", "bar");
+        Map<String, Object> specification = Map.of("foo", "bar");
         var response = new GraphQLResponseBody(specification);
         var expected = """
             {"foo":"bar"}""";
@@ -25,7 +25,7 @@ class GraphQLJacksonSerializationTest {
 
     @Test
     void serializeEmptyGraphQLResponseBody(JsonMapper mapper) throws IOException {
-        Map<String, Object> specification = Collections.singletonMap("foo", Map.of("bar", Collections.emptyList()));
+        Map<String, Object> specification = Map.of("foo", Map.of("bar", Collections.emptyList()));
         var response = new GraphQLResponseBody(specification);
         var expected = """
             {"foo":{"bar":[]}}""";

--- a/test-suite-serde/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
+++ b/test-suite-serde/src/test/java/example/micronaut/GraphQLJacksonSerializationTest.java
@@ -16,9 +16,19 @@ class GraphQLJacksonSerializationTest {
 
     @Test
     void serializeGraphQLResponseBody(JsonMapper mapper) throws IOException {
-        Map<String, Object> specification = Collections.singletonMap("foo", "bar");
+        Map<String, Object> specification = Map.of("foo", "bar");
         var response = new GraphQLResponseBody(specification);
-        var expected = "{\"foo\":\"bar\"}";
+        var expected = """
+            {"foo":"bar"}""";
+        assertEquals(expected, mapper.writeValueAsString(response));
+    }
+
+    @Test
+    void serializeEmptyGraphQLResponseBody(JsonMapper mapper) throws IOException {
+        Map<String, Object> specification = Map.of("foo", Map.of("bar", Collections.emptyList()));
+        var response = new GraphQLResponseBody(specification);
+        var expected = """
+            {"foo":{"bar":[]}}""";
         assertEquals(expected, mapper.writeValueAsString(response));
     }
 }


### PR DESCRIPTION
GraphQL projects using jackson serialization were failing as they dropped all null and empty elements during serialization.

This change exposes micronaut.serde.jackson as an API dependency.

Closes #489
Closes #462

@sdelamo I've presumptiously added this to the 4.3.0 release as it would be good for it to go out with that