### PR TITLE
 Return 400 for malformed GraphQL JSON requests

### DIFF
--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.micronaut.http.HttpStatus.BAD_REQUEST;
 import static io.micronaut.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static io.micronaut.http.MediaType.ALL;
 import static io.micronaut.http.MediaType.APPLICATION_GRAPHQL_TYPE;
@@ -147,7 +148,12 @@ public class GraphQLController {
         // }
 
         if (APPLICATION_JSON_TYPE.equals(contentType)) {
-            GraphQLRequestBody request = graphQLJsonSerializer.deserialize(body, GraphQLRequestBody.class);
+            GraphQLRequestBody request;
+            try {
+                request = graphQLJsonSerializer.deserialize(body, GraphQLRequestBody.class);
+            } catch (RuntimeException e) {
+                throw new HttpStatusException(BAD_REQUEST, "Invalid JSON in GraphQL request body");
+            }
             if (request.getQuery() == null) {
                 request.setQuery("");
             }
@@ -177,7 +183,11 @@ public class GraphQLController {
         if (jsonMap == null) {
             return Collections.emptyMap();
         }
-        return graphQLJsonSerializer.deserialize(jsonMap, Map.class);
+        try {
+            return graphQLJsonSerializer.deserialize(jsonMap, Map.class);
+        } catch (RuntimeException e) {
+            throw new HttpStatusException(BAD_REQUEST, "Invalid JSON in GraphQL variables");
+        }
     }
 
     /**

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -32,6 +32,7 @@ import io.micronaut.core.async.publisher.Publishers
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Get
@@ -78,7 +79,7 @@ class GraphQLControllerSpec extends Specification {
         embeddedServer.applicationContext.registerSingleton(GraphQL, graphQL)
         graphQLClient = embeddedServer.applicationContext.getBean(GraphQLClient)
         executionInput = null
-        1 * graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
+        graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
             this.executionInput = executionInput
             if (executionInput.query == "{ testHeaders }") {
                 GraphQLContext graphQlContext = executionInput.getGraphQLContext()
@@ -280,6 +281,33 @@ class GraphQLControllerSpec extends Specification {
         httpResponse.header("set-cookie") == "foo=bar"
     }
 
+    void "test post with malformed application json body returns bad request"() {
+        when:
+        graphQLClient.postMalformedJson('Bad request')
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.BAD_REQUEST
+    }
+
+    void "test get with malformed variables returns bad request"() {
+        when:
+        graphQLClient.get('{ foo }', null, '{invalid json}')
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.BAD_REQUEST
+    }
+
+    void "test post with malformed variables returns bad request"() {
+        when:
+        graphQLClient.post('{ foo }', null, '{invalid json}')
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.BAD_REQUEST
+    }
+
     @Client("/graphql")
     static interface GraphQLClient {
 
@@ -297,6 +325,9 @@ class GraphQLControllerSpec extends Specification {
 
         @Post(produces = APPLICATION_GRAPHQL)
         HttpResponse<GraphQLResponseBody> postWithResponse(@Body String body)
+
+        @Post(consumes = APPLICATION_JSON)
+        GraphQLResponseBody postMalformedJson(@Body String body)
 
     }
 


### PR DESCRIPTION
-  Map malformed GraphQL request body and variables JSON parsing failures to HTTP 400 and add regression tests for both paths. 
-Closes: #555 