### PR TITLE
docs: add DataLoader example documentation

### DIFF
--- a/examples/todo-java-tools/README.md
+++ b/examples/todo-java-tools/README.md
@@ -2,6 +2,8 @@
 
 Demonstrates the usage of [graphql-java-tools](https://www.graphql-java-kickstart.com/tools/) which provides APIs to support more easily build a GraphQL endpoint based off your schema and domain objects.
 
+This example also shows how to use a GraphQL `DataLoader` to batch nested author lookups for the `ToDo.author` field.
+
 ## Running
 
 Start the application:
@@ -9,3 +11,28 @@ Start the application:
     ./gradlew clean :graphql-example-todo-java-tools:run
     
 Open the embedded [Graph<i>i</i>QL](http://localhost:8080/graphiql) IDE to interact with the GraphQL To-Do API.
+
+## DataLoader flow
+
+The `todo-java-tools` example wires the `author` field through a request-scoped data loader:
+
+* `DataLoaderRegistryFactory` creates a new `DataLoaderRegistry` for each request and registers the `author` data loader.
+* `AuthorDataLoader` implements `MappedBatchLoader<String, Author>` and batches author lookups through `AuthorRepository`.
+* `ToDoResolver` manually retrieves the loader from `DataFetchingEnvironment` and calls `load(todo.getAuthorId())`.
+
+The `@RequestScope` on `DataLoaderRegistryFactory` is important. It ensures every GraphQL request gets a fresh loader registry and cache.
+
+GraphQL does not invoke the data loader automatically. The resolver must call it for the field that should be batched.
+
+To exercise the data loader, run a query that resolves authors for multiple todos:
+
+```graphql
+query {
+  toDos {
+    title
+    author {
+      username
+    }
+  }
+}
+```

--- a/examples/todo-java-tools/README.md
+++ b/examples/todo-java-tools/README.md
@@ -14,13 +14,13 @@ Open the embedded [Graph<i>i</i>QL](http://localhost:8080/graphiql) IDE to inter
 
 ## DataLoader flow
 
-The `todo-java-tools` example wires the `author` field through a request-scoped data loader:
+The `todo-java-tools` example wires the `author` field through a request-scoped `DataLoaderRegistry` (and loader cache):
 
 * `DataLoaderRegistryFactory` creates a new `DataLoaderRegistry` for each request and registers the `author` data loader.
 * `AuthorDataLoader` implements `MappedBatchLoader<String, Author>` and batches author lookups through `AuthorRepository`.
 * `ToDoResolver` manually retrieves the loader from `DataFetchingEnvironment` and calls `load(todo.getAuthorId())`.
 
-The `@RequestScope` on `DataLoaderRegistryFactory` is important. It ensures every GraphQL request gets a fresh loader registry and cache.
+The `@RequestScope` on the `dataLoaderRegistry()` bean method inside `DataLoaderRegistryFactory` is important. It ensures every GraphQL request gets a fresh loader registry and cache.
 
 GraphQL does not invoke the data loader automatically. The resolver must call it for the field that should be batched.
 

--- a/src/main/docs/guide/configuration/data-loaders.adoc
+++ b/src/main/docs/guide/configuration/data-loaders.adoc
@@ -14,12 +14,13 @@ https://github.com/graphql-java-kickstart/graphql-java-tools[GraphQL Java Tools]
 This pattern matters for two reasons:
 
 * The registry should be `@RequestScope` so every GraphQL request gets a fresh loader cache.
-* GraphQL does not invoke Micronaut `DataLoader`s automatically. A resolver or `DataFetcher` must obtain the loader
-  from the `DataFetchingEnvironment` and call it for the field that should be batched.
+* GraphQL does not invoke https://github.com/graphql-java/java-dataloader[java-dataloader] `DataLoader`s automatically.
+  A resolver or `DataFetcher` must obtain the loader from the `DataFetchingEnvironment` and call `load(...)` for the
+  field that should be batched.
 
 You can explore the example here:
 
-* https://github.com/micronaut-projects/micronaut-graphql/tree/master/examples/todo-java-tools[`examples/todo-java-tools`]
-* https://github.com/micronaut-projects/micronaut-graphql/blob/master/examples/todo-java-tools/src/main/java/example/graphql/DataLoaderRegistryFactory.java[`DataLoaderRegistryFactory`]
-* https://github.com/micronaut-projects/micronaut-graphql/blob/master/examples/todo-java-tools/src/main/java/example/graphql/AuthorDataLoader.java[`AuthorDataLoader`]
-* https://github.com/micronaut-projects/micronaut-graphql/blob/master/examples/todo-java-tools/src/main/java/example/graphql/ToDoResolver.java[`ToDoResolver`]
+* https://github.com/{githubSlug}/tree/master/examples/todo-java-tools[`examples/todo-java-tools`]
+* https://github.com/{githubSlug}/blob/master/examples/todo-java-tools/src/main/java/example/graphql/DataLoaderRegistryFactory.java[`DataLoaderRegistryFactory`]
+* https://github.com/{githubSlug}/blob/master/examples/todo-java-tools/src/main/java/example/graphql/AuthorDataLoader.java[`AuthorDataLoader`]
+* https://github.com/{githubSlug}/blob/master/examples/todo-java-tools/src/main/java/example/graphql/ToDoResolver.java[`ToDoResolver`]

--- a/src/main/docs/guide/configuration/dataLoaders.adoc
+++ b/src/main/docs/guide/configuration/dataLoaders.adoc
@@ -1,0 +1,25 @@
+A Micronaut application can expose https://github.com/graphql-java/java-dataloader[java-dataloader] instances to GraphQL
+by defining a request-scoped `org.dataloader.DataLoaderRegistry` bean.
+
+The `todo-java-tools` example in this repository shows the full flow when using
+https://github.com/graphql-java-kickstart/graphql-java-tools[GraphQL Java Tools]:
+
+* `example.graphql.DataLoaderRegistryFactory` creates a new `DataLoaderRegistry` for each request and registers the
+  `author` loader.
+* `example.graphql.AuthorDataLoader` implements `MappedBatchLoader<String, Author>` and batches the author lookups by
+  delegating to `AuthorRepository#findAllById`.
+* `example.graphql.ToDoResolver` gets the loader from `graphql.schema.DataFetchingEnvironment` and calls
+  `load(todo.getAuthorId())` when the `author` field is resolved.
+
+This pattern matters for two reasons:
+
+* The registry should be `@RequestScope` so every GraphQL request gets a fresh loader cache.
+* GraphQL does not invoke Micronaut `DataLoader`s automatically. A resolver or `DataFetcher` must obtain the loader
+  from the `DataFetchingEnvironment` and call it for the field that should be batched.
+
+You can explore the example here:
+
+* https://github.com/micronaut-projects/micronaut-graphql/tree/master/examples/todo-java-tools[`examples/todo-java-tools`]
+* https://github.com/micronaut-projects/micronaut-graphql/blob/master/examples/todo-java-tools/src/main/java/example/graphql/DataLoaderRegistryFactory.java[`DataLoaderRegistryFactory`]
+* https://github.com/micronaut-projects/micronaut-graphql/blob/master/examples/todo-java-tools/src/main/java/example/graphql/AuthorDataLoader.java[`AuthorDataLoader`]
+* https://github.com/micronaut-projects/micronaut-graphql/blob/master/examples/todo-java-tools/src/main/java/example/graphql/ToDoResolver.java[`ToDoResolver`]

--- a/src/main/docs/guide/configuration/graphql-bean.adoc
+++ b/src/main/docs/guide/configuration/graphql-bean.adoc
@@ -14,3 +14,6 @@ snippet::io.micronaut.graphql.docs.GraphQLFactory[tags="imports,clazz", project-
 
 There are various https://github.com/micronaut-projects/micronaut-graphql/tree/master/examples[examples] using different technologies
 provided in the repository.
+
+For an example that combines GraphQL Java Tools with a request-scoped `DataLoaderRegistry`, see the xref:dataLoaders.adoc[Using DataLoaders]
+section and the `todo-java-tools` example in this repository.

--- a/src/main/docs/guide/configuration/graphql-bean.adoc
+++ b/src/main/docs/guide/configuration/graphql-bean.adoc
@@ -15,5 +15,5 @@ snippet::io.micronaut.graphql.docs.GraphQLFactory[tags="imports,clazz", project-
 There are various https://github.com/micronaut-projects/micronaut-graphql/tree/master/examples[examples] using different technologies
 provided in the repository.
 
-For an example that combines GraphQL Java Tools with a request-scoped `DataLoaderRegistry`, see the xref:data-loaders.adoc[Using DataLoaders]
+For an example that combines GraphQL Java Tools with a request-scoped `DataLoaderRegistry`, see the <<data-loaders, Using DataLoaders>>
 section and the `todo-java-tools` example in this repository.

--- a/src/main/docs/guide/configuration/graphql-bean.adoc
+++ b/src/main/docs/guide/configuration/graphql-bean.adoc
@@ -15,5 +15,5 @@ snippet::io.micronaut.graphql.docs.GraphQLFactory[tags="imports,clazz", project-
 There are various https://github.com/micronaut-projects/micronaut-graphql/tree/master/examples[examples] using different technologies
 provided in the repository.
 
-For an example that combines GraphQL Java Tools with a request-scoped `DataLoaderRegistry`, see the xref:dataLoaders.adoc[Using DataLoaders]
+For an example that combines GraphQL Java Tools with a request-scoped `DataLoaderRegistry`, see the xref:data-loaders.adoc[Using DataLoaders]
 section and the `todo-java-tools` example in this repository.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,6 +5,7 @@ quickStart: Quick Start
 configuration:
   title: Configuration
   graphql-bean: Configuring the GraphQL Bean
+  dataLoaders: Using DataLoaders
   graphql-ws: Configuring GraphQL over websockets
   graphiql: Configuring GraphiQL
   jackson: Notes on using Jackson serialization

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,7 +5,7 @@ quickStart: Quick Start
 configuration:
   title: Configuration
   graphql-bean: Configuring the GraphQL Bean
-  dataLoaders: Using DataLoaders
+  data-loaders: Using DataLoaders
   graphql-ws: Configuring GraphQL over websockets
   graphiql: Configuring GraphiQL
   jackson: Notes on using Jackson serialization


### PR DESCRIPTION
## Summary
- document the existing DataLoader flow in the `todo-java-tools` example README
- add a guide section for using a request-scoped `DataLoaderRegistry` with GraphQL Java Tools
- link the new guide section from the GraphQL bean configuration docs

## Verification
- ./gradlew :micronaut-graphql-example-todo-java-tools:assemble
- ./gradlew publishGuide
- ./gradlew docs

Resolves #41