### PR TITLE
Add support for Apollo-style batched query requests

### DIFF
--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static io.micronaut.http.HttpStatus.BAD_REQUEST;
@@ -207,9 +208,8 @@ public class GraphQLController {
         List<GraphQLRequestBody> batchRequests = requests == null ? Collections.emptyList() : Arrays.asList(requests);
         return Flux.fromIterable(batchRequests)
                 .concatMap(request -> {
-                    GraphQLRequestBody batchRequest = request == null
-                            ? newRequestBody(null, null, Collections.emptyMap())
-                            : request;
+                    GraphQLRequestBody batchRequest = Objects.requireNonNullElseGet(
+                            request, () -> newRequestBody(null, null, Collections.emptyMap()));
                     MutableHttpResponse<String> operationHttpResponse = HttpResponse.status(HttpStatus.OK);
                     return Flux.from(executeGraphQLRequest(batchRequest, httpRequest, operationHttpResponse));
                 })

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -17,7 +17,6 @@ package io.micronaut.configuration.graphql;
 
 import graphql.ExecutionResult;
 import org.jspecify.annotations.Nullable;
-import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
@@ -30,8 +29,12 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.exceptions.HttpStatusException;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -148,6 +151,15 @@ public class GraphQLController {
         // }
 
         if (APPLICATION_JSON_TYPE.equals(contentType)) {
+            if (body.trim().startsWith("[")) {
+                try {
+                    GraphQLRequestBody[] requests = graphQLJsonSerializer.deserialize(body, GraphQLRequestBody[].class);
+                    return executeBatchRequests(requests, httpRequest);
+                } catch (RuntimeException e) {
+                    throw new HttpStatusException(BAD_REQUEST, "Invalid JSON in GraphQL request body");
+                }
+            }
+
             GraphQLRequestBody request;
             try {
                 request = graphQLJsonSerializer.deserialize(body, GraphQLRequestBody.class);
@@ -157,7 +169,7 @@ public class GraphQLController {
             if (request.getQuery() == null) {
                 request.setQuery("");
             }
-            return executeRequest(request.getQuery(), request.getOperationName(), request.getVariables(), httpRequest);
+            return executeRequest(request, httpRequest);
         }
 
         // In addition to the above, we recommend supporting two additional cases:
@@ -190,6 +202,21 @@ public class GraphQLController {
         }
     }
 
+    private Publisher<MutableHttpResponse<String>> executeBatchRequests(GraphQLRequestBody[] requests, HttpRequest httpRequest) {
+        MutableHttpResponse<String> httpResponse = HttpResponse.status(HttpStatus.OK);
+        List<GraphQLRequestBody> batchRequests = requests == null ? Collections.emptyList() : Arrays.asList(requests);
+        return Flux.fromIterable(batchRequests)
+                .concatMap(request -> Flux.from(executeGraphQLRequest(request, httpRequest, httpResponse)))
+                .collectList()
+                .map(graphQLResponseBodies -> httpResponse.body(graphQLJsonSerializer.serialize(graphQLResponseBodies)));
+    }
+
+    private Publisher<MutableHttpResponse<String>> executeRequest(GraphQLRequestBody request, HttpRequest httpRequest) {
+        MutableHttpResponse<String> httpResponse = HttpResponse.status(HttpStatus.OK);
+        return Mono.from(executeGraphQLRequest(request, httpRequest, httpResponse))
+                .map(graphQLResponseBody -> httpResponse.body(graphQLJsonSerializer.serialize(graphQLResponseBody)));
+    }
+
     /**
      * Executes the GraphQL request and returns the serialized {@link GraphQLResponseBody}.
      *
@@ -204,11 +231,34 @@ public class GraphQLController {
             String operationName,
             Map<String, Object> variables,
             HttpRequest httpRequest) {
-        GraphQLInvocationData invocationData = new GraphQLInvocationData(query, operationName, variables);
+        return executeRequest(newRequestBody(query, operationName, variables), httpRequest);
+    }
+
+    private Publisher<GraphQLResponseBody> executeGraphQLRequest(
+            GraphQLRequestBody request,
+            HttpRequest httpRequest,
+            MutableHttpResponse<String> httpResponse) {
+        GraphQLInvocationData invocationData = new GraphQLInvocationData(
+                normalizeQuery(request.getQuery()),
+                request.getOperationName(),
+                request.getVariables());
         // create empty response entity first and pass it to GraphQLInvocation
-        MutableHttpResponse<String> httpResponse = HttpResponse.status(HttpStatus.OK);
         Publisher<ExecutionResult> executionResult = graphQLInvocation.invoke(invocationData, httpRequest, httpResponse);
-        Publisher<GraphQLResponseBody> responseBody = graphQLExecutionResultHandler.handleExecutionResult(executionResult);
-        return Publishers.map(responseBody, graphQLResponseBody -> httpResponse.body(graphQLJsonSerializer.serialize(graphQLResponseBody)));
+        return graphQLExecutionResultHandler.handleExecutionResult(executionResult);
+    }
+
+    private GraphQLRequestBody newRequestBody(String query, String operationName, Map<String, Object> variables) {
+        GraphQLRequestBody request = new GraphQLRequestBody();
+        request.setQuery(query);
+        request.setOperationName(operationName);
+        request.setVariables(variables);
+        return request;
+    }
+
+    private String normalizeQuery(String query) {
+        if (query == null) {
+            return "";
+        }
+        return query;
     }
 }

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -203,12 +203,18 @@ public class GraphQLController {
     }
 
     private Publisher<MutableHttpResponse<String>> executeBatchRequests(GraphQLRequestBody[] requests, HttpRequest httpRequest) {
-        MutableHttpResponse<String> httpResponse = HttpResponse.status(HttpStatus.OK);
+        MutableHttpResponse<String> batchHttpResponse = HttpResponse.status(HttpStatus.OK);
         List<GraphQLRequestBody> batchRequests = requests == null ? Collections.emptyList() : Arrays.asList(requests);
         return Flux.fromIterable(batchRequests)
-                .concatMap(request -> Flux.from(executeGraphQLRequest(request, httpRequest, httpResponse)))
+                .concatMap(request -> {
+                    GraphQLRequestBody batchRequest = request == null
+                            ? newRequestBody(null, null, Collections.emptyMap())
+                            : request;
+                    MutableHttpResponse<String> operationHttpResponse = HttpResponse.status(HttpStatus.OK);
+                    return Flux.from(executeGraphQLRequest(batchRequest, httpRequest, operationHttpResponse));
+                })
                 .collectList()
-                .map(graphQLResponseBodies -> httpResponse.body(graphQLJsonSerializer.serialize(graphQLResponseBodies)));
+                .map(graphQLResponseBodies -> batchHttpResponse.body(graphQLJsonSerializer.serialize(graphQLResponseBodies)));
     }
 
     private Publisher<MutableHttpResponse<String>> executeRequest(GraphQLRequestBody request, HttpRequest httpRequest) {

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -29,6 +29,7 @@ import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import io.micronaut.core.annotation.Nullable
 import io.micronaut.core.async.publisher.Publishers
+import io.micronaut.core.type.Argument
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -38,6 +39,7 @@ import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.cookie.Cookie
 import io.micronaut.runtime.server.EmbeddedServer
@@ -62,8 +64,10 @@ class GraphQLControllerSpec extends Specification {
 
     GraphQL graphQL
     GraphQLClient graphQLClient
+    HttpClient httpClient
 
     ExecutionInput executionInput
+    List<ExecutionInput> executionInputs
 
     CompletableFuture<ExecutionResult> executionResult = CompletableFuture.completedFuture(
             ExecutionResultImpl.newExecutionResult()
@@ -78,9 +82,12 @@ class GraphQLControllerSpec extends Specification {
                 Environment.TEST)
         embeddedServer.applicationContext.registerSingleton(GraphQL, graphQL)
         graphQLClient = embeddedServer.applicationContext.getBean(GraphQLClient)
+        httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
         executionInput = null
-        graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
+        executionInputs = []
+        _ * graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
             this.executionInput = executionInput
+            this.executionInputs << executionInput
             if (executionInput.query == "{ testHeaders }") {
                 GraphQLContext graphQlContext = executionInput.getGraphQLContext()
 
@@ -249,6 +256,31 @@ class GraphQLControllerSpec extends Specification {
         executionInput.query == body.query
         executionInput.operationName == body.operationName
         executionInput.variables == body.variables
+    }
+
+    void "test post with application/json batch body"() {
+        given:
+        String body = '''
+[
+  {"query":"{ foo }"},
+  {"query":"query myQuery { foo }","operationName":"myQuery","variables":{"variable":"variableValue"}}
+]
+'''
+
+        when:
+        HttpResponse<List<GraphQLResponseBody>> response = httpClient.toBlocking().exchange(
+                io.micronaut.http.HttpRequest.POST("/graphql", body).contentType(APPLICATION_JSON),
+                Argument.listOf(GraphQLResponseBody))
+        List<GraphQLResponseBody> batchResponse = response.body()
+
+        then:
+        response.status() == HttpStatus.OK
+        batchResponse*.specification*.data == ["bar", "bar"]
+
+        and:
+        executionInputs*.query == ["{ foo }", "query myQuery { foo }"]
+        executionInputs*.operationName == [null, "myQuery"]
+        executionInputs*.variables == [[:], ["variable": "variableValue"]]
     }
 
     void "test post with application/graphql body"() {

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -64,6 +64,7 @@ class GraphQLControllerSpec extends Specification {
 
     GraphQL graphQL
     GraphQLClient graphQLClient
+    @AutoCleanup
     HttpClient httpClient
 
     ExecutionInput executionInput
@@ -113,6 +114,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == query
         executionInput.operationName == null
         executionInput.variables == [:]
@@ -130,6 +132,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == query
         executionInput.operationName == operationName
         executionInput.variables == [:]
@@ -148,6 +151,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == query
         executionInput.operationName == operationName
         executionInput.variables == ["variable": "variableValue"]
@@ -164,6 +168,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == query
         executionInput.operationName == null
         executionInput.variables == [:]
@@ -181,6 +186,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == query
         executionInput.operationName == operationName
         executionInput.variables == [:]
@@ -199,6 +205,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == query
         executionInput.operationName == operationName
         executionInput.variables == ["variable": "variableValue"]
@@ -216,6 +223,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == body.query
         executionInput.operationName == null
         executionInput.variables == [:]
@@ -234,6 +242,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == body.query
         executionInput.operationName == body.operationName
         executionInput.variables == [:]
@@ -253,6 +262,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == body.query
         executionInput.operationName == body.operationName
         executionInput.variables == body.variables
@@ -278,6 +288,7 @@ class GraphQLControllerSpec extends Specification {
         batchResponse*.specification*.data == ["bar", "bar"]
 
         and:
+        executionInputs.size() == 2
         executionInputs*.query == ["{ foo }", "query myQuery { foo }"]
         executionInputs*.operationName == [null, "myQuery"]
         executionInputs*.variables == [[:], ["variable": "variableValue"]]
@@ -294,6 +305,7 @@ class GraphQLControllerSpec extends Specification {
         response.getSpecification()["data"] == "bar"
 
         and:
+        executionInputs.size() == 1
         executionInput.query == body
         executionInput.operationName == null
         executionInput.variables == [:]
@@ -311,6 +323,9 @@ class GraphQLControllerSpec extends Specification {
         httpResponse.body().getSpecification()["data"] == "bar"
         httpResponse.header("X-Foo") == "bar"
         httpResponse.header("set-cookie") == "foo=bar"
+
+        and:
+        executionInputs.size() == 1
     }
 
     void "test post with malformed application json body returns bad request"() {


### PR DESCRIPTION
## Summary
- accept Apollo-style batched JSON POST payloads at the GraphQL controller
- execute each request in order and serialize the responses as a JSON array
- cover the new behavior with a controller test that asserts response and execution inputs

## Verification
- ./gradlew :micronaut-graphql:test --tests io.micronaut.configuration.graphql.GraphQLControllerSpec
- ./gradlew :micronaut-graphql:test

Resolves #22