### PR TITLE
Support GraphQL multipart requests

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.0.1
+projectVersion=5.1.0-SNAPSHOT
 projectGroup=io.micronaut.graphql
 
 title=Micronaut GraphQL Integration

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -29,9 +29,19 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.multipart.CompletedPart;
+import io.micronaut.http.server.multipart.MultipartBody;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -41,6 +51,7 @@ import static io.micronaut.http.MediaType.ALL;
 import static io.micronaut.http.MediaType.APPLICATION_GRAPHQL_TYPE;
 import static io.micronaut.http.MediaType.APPLICATION_JSON;
 import static io.micronaut.http.MediaType.APPLICATION_JSON_TYPE;
+import static io.micronaut.http.MediaType.MULTIPART_FORM_DATA;
 
 /**
  * The GraphQL controller handling GraphQL requests.
@@ -109,6 +120,45 @@ public class GraphQLController {
         // an "operationName" query parameter can be used to control which one should be executed.
 
         return executeRequest(query, operationName, convertVariablesJson(variables), httpRequest);
+    }
+
+    /**
+     * Handles GraphQL {@code POST} multipart requests.
+     *
+     * @param body        the multipart request body
+     * @param httpRequest the HTTP request
+     * @return the GraphQL response
+     */
+    @ExecuteOn(TaskExecutors.BLOCKING)
+    @Post(consumes = MULTIPART_FORM_DATA, produces = APPLICATION_JSON, single = true)
+    public Publisher<MutableHttpResponse<String>> postMultipart(@Body MultipartBody body, HttpRequest httpRequest) {
+        return Flux.from(body)
+                .collectMap(CompletedPart::getName, part -> part)
+                .flatMapMany(parts -> {
+                    GraphQLRequestBody requestBody = graphQLJsonSerializer.deserialize(
+                            partToString(getRequiredPart(parts, "operations")),
+                            GraphQLRequestBody.class
+                    );
+                    if (requestBody.getQuery() == null) {
+                        requestBody.setQuery("");
+                    }
+                    if (requestBody.getVariables() == null) {
+                        requestBody.setVariables(new LinkedHashMap<>());
+                    }
+                    Map<String, Object> multipartMapping = convertVariablesJson(partToString(getRequiredPart(parts, "map")));
+                    for (Map.Entry<String, Object> entry : multipartMapping.entrySet()) {
+                        CompletedPart uploadedPart = getRequiredPart(parts, entry.getKey());
+                        for (String variablePath : asVariablePaths(entry.getValue())) {
+                            injectMultipartVariable(requestBody.getVariables(), variablePath, uploadedPart);
+                        }
+                    }
+                    return Flux.from(executeRequest(
+                            requestBody.getQuery(),
+                            requestBody.getOperationName(),
+                            requestBody.getVariables(),
+                            httpRequest
+                    ));
+                });
     }
 
     /**
@@ -187,6 +237,88 @@ public class GraphQLController {
             return graphQLJsonSerializer.deserialize(jsonMap, Map.class);
         } catch (RuntimeException e) {
             throw new HttpStatusException(BAD_REQUEST, "Invalid JSON in GraphQL variables");
+        }
+    }
+
+    private CompletedPart getRequiredPart(Map<String, CompletedPart> parts, String name) {
+        CompletedPart part = parts.get(name);
+        if (part == null) {
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Missing multipart field: " + name);
+        }
+        return part;
+    }
+
+    private List<String> asVariablePaths(Object mappingValue) {
+        if (mappingValue instanceof String mappingPath) {
+            return List.of(mappingPath);
+        }
+        if (mappingValue instanceof List<?> mappingPaths) {
+            List<String> variablePaths = new ArrayList<>(mappingPaths.size());
+            for (Object mappingPath : mappingPaths) {
+                if (mappingPath instanceof String stringPath) {
+                    variablePaths.add(stringPath);
+                    continue;
+                }
+                throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Invalid multipart mapping payload");
+            }
+            return variablePaths;
+        }
+        throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Invalid multipart mapping payload");
+    }
+
+    @SuppressWarnings("unchecked")
+    private void injectMultipartVariable(Map<String, Object> variables, String variablePath, CompletedPart part) {
+        String[] pathSegments = variablePath.split("\\.");
+        if (pathSegments.length < 2 || !"variables".equals(pathSegments[0])) {
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unsupported multipart variable path: " + variablePath);
+        }
+
+        Object current = variables;
+        for (int i = 1; i < pathSegments.length - 1; i++) {
+            String segment = pathSegments[i];
+            if (current instanceof Map<?, ?> currentMap) {
+                if (!currentMap.containsKey(segment)) {
+                    throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
+                }
+                current = ((Map<String, Object>) currentMap).get(segment);
+                continue;
+            }
+            if (current instanceof List<?> currentList) {
+                current = currentList.get(parsePathIndex(segment, currentList.size(), variablePath));
+                continue;
+            }
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
+        }
+
+        String leafSegment = pathSegments[pathSegments.length - 1];
+        if (current instanceof Map<?, ?> currentMap) {
+            ((Map<String, Object>) currentMap).put(leafSegment, part);
+            return;
+        }
+        if (current instanceof List<?> currentList) {
+            ((List<Object>) currentList).set(parsePathIndex(leafSegment, currentList.size(), variablePath), part);
+            return;
+        }
+        throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
+    }
+
+    private int parsePathIndex(String segment, int size, String variablePath) {
+        try {
+            int index = Integer.parseInt(segment);
+            if (index < 0 || index >= size) {
+                throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
+            }
+            return index;
+        } catch (NumberFormatException e) {
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
+        }
+    }
+
+    private String partToString(CompletedPart part) {
+        try {
+            return new String(part.getBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Could not process multipart field: " + part.getName());
         }
     }
 

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -307,7 +307,8 @@ public class GraphQLController {
     }
 
     private void replaceMultipartMapLeaf(Map<String, Object> currentMap, String leafSegment, String variablePath, CompletedPart part) {
-        if (!currentMap.containsKey(leafSegment) || currentMap.get(leafSegment) != null) {
+        Object existing = currentMap.get(leafSegment);
+        if (existing != null || !currentMap.containsKey(leafSegment)) {
             throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Invalid multipart variable path: " + variablePath);
         }
         currentMap.put(leafSegment, part);

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -29,6 +29,7 @@ import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.exceptions.HttpStatusException;
+import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.multipart.CompletedPart;
 import io.micronaut.http.server.multipart.MultipartBody;
 import io.micronaut.scheduling.TaskExecutors;
@@ -147,7 +148,10 @@ public class GraphQLController {
                     }
                     Map<String, Object> multipartMapping = convertVariablesJson(partToString(getRequiredPart(parts, "map")));
                     for (Map.Entry<String, Object> entry : multipartMapping.entrySet()) {
-                        CompletedPart uploadedPart = getRequiredPart(parts, entry.getKey());
+                        CompletedPart rawPart = getRequiredPart(parts, entry.getKey());
+                        if (!(rawPart instanceof CompletedFileUpload uploadedPart)) {
+                            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Multipart field is not a file upload: " + entry.getKey());
+                        }
                         for (String variablePath : asVariablePaths(entry.getValue())) {
                             injectMultipartVariable(requestBody.getVariables(), variablePath, uploadedPart);
                         }
@@ -292,14 +296,29 @@ public class GraphQLController {
 
         String leafSegment = pathSegments[pathSegments.length - 1];
         if (current instanceof Map<?, ?> currentMap) {
-            ((Map<String, Object>) currentMap).put(leafSegment, part);
+            replaceMultipartMapLeaf((Map<String, Object>) currentMap, leafSegment, variablePath, part);
             return;
         }
         if (current instanceof List<?> currentList) {
-            ((List<Object>) currentList).set(parsePathIndex(leafSegment, currentList.size(), variablePath), part);
+            replaceMultipartListLeaf((List<Object>) currentList, leafSegment, variablePath, part);
             return;
         }
         throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
+    }
+
+    private void replaceMultipartMapLeaf(Map<String, Object> currentMap, String leafSegment, String variablePath, CompletedPart part) {
+        if (!currentMap.containsKey(leafSegment) || currentMap.get(leafSegment) != null) {
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Invalid multipart variable path: " + variablePath);
+        }
+        currentMap.put(leafSegment, part);
+    }
+
+    private void replaceMultipartListLeaf(List<Object> currentList, String leafSegment, String variablePath, CompletedPart part) {
+        int index = parsePathIndex(leafSegment, currentList.size(), variablePath);
+        if (currentList.get(index) != null) {
+            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Invalid multipart variable path: " + variablePath);
+        }
+        currentList.set(index, part);
     }
 
     private int parsePathIndex(String segment, int size, String variablePath) {

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -144,11 +144,15 @@ public class GraphQLController {
                     } catch (RuntimeException _) {
                         throw new HttpStatusException(BAD_REQUEST, "Invalid JSON in GraphQL request body");
                     }
-                    if (requestBody.getQuery() == null) {
-                        requestBody.setQuery("");
+                    String requestQuery = requestBody.getQuery();
+                    if (requestQuery == null) {
+                        requestQuery = "";
+                        requestBody.setQuery(requestQuery);
                     }
-                    if (requestBody.getVariables() == null) {
-                        requestBody.setVariables(new LinkedHashMap<>());
+                    Map<String, Object> requestVariables = requestBody.getVariables();
+                    if (requestVariables == null) {
+                        requestVariables = new LinkedHashMap<>();
+                        requestBody.setVariables(requestVariables);
                     }
                     Map<String, Object> multipartMapping = convertVariablesJson(partToString(getRequiredPart(parts, "map")));
                     for (Map.Entry<String, Object> entry : multipartMapping.entrySet()) {
@@ -157,13 +161,13 @@ public class GraphQLController {
                             throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Multipart field is not a file upload: " + entry.getKey());
                         }
                         for (String variablePath : asVariablePaths(entry.getValue())) {
-                            injectMultipartVariable(requestBody.getVariables(), variablePath, uploadedPart);
+                            injectMultipartVariable(requestVariables, variablePath, uploadedPart);
                         }
                     }
                     return Flux.from(executeRequest(
-                            requestBody.getQuery(),
+                            requestQuery,
                             requestBody.getOperationName(),
-                            requestBody.getVariables(),
+                            requestVariables,
                             httpRequest
                     ));
                 });

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static io.micronaut.http.HttpStatus.BAD_REQUEST;
 import static io.micronaut.http.HttpStatus.UNPROCESSABLE_ENTITY;
@@ -132,14 +133,17 @@ public class GraphQLController {
      */
     @ExecuteOn(TaskExecutors.BLOCKING)
     @Post(consumes = MULTIPART_FORM_DATA, produces = APPLICATION_JSON, single = true)
-    public Publisher<MutableHttpResponse<String>> postMultipart(@Body MultipartBody body, HttpRequest httpRequest) {
+    public Publisher<MutableHttpResponse<String>> postMultipart(@Body MultipartBody body, HttpRequest<?> httpRequest) {
         return Flux.from(body)
-                .collectMap(CompletedPart::getName, part -> part)
+                .collectMap(CompletedPart::getName, Function.<CompletedPart>identity())
                 .flatMapMany(parts -> {
-                    GraphQLRequestBody requestBody = graphQLJsonSerializer.deserialize(
-                            partToString(getRequiredPart(parts, "operations")),
-                            GraphQLRequestBody.class
-                    );
+                    String operationsJson = partToString(getRequiredPart(parts, "operations"));
+                    GraphQLRequestBody requestBody;
+                    try {
+                        requestBody = graphQLJsonSerializer.deserialize(operationsJson, GraphQLRequestBody.class);
+                    } catch (RuntimeException _) {
+                        throw new HttpStatusException(BAD_REQUEST, "Invalid JSON in GraphQL request body");
+                    }
                     if (requestBody.getQuery() == null) {
                         requestBody.setQuery("");
                     }
@@ -285,13 +289,11 @@ public class GraphQLController {
                     throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
                 }
                 current = ((Map<String, Object>) currentMap).get(segment);
-                continue;
-            }
-            if (current instanceof List<?> currentList) {
+            } else if (current instanceof List<?> currentList) {
                 current = currentList.get(parsePathIndex(segment, currentList.size(), variablePath));
-                continue;
+            } else {
+                throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
             }
-            throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
         }
 
         String leafSegment = pathSegments[pathSegments.length - 1];
@@ -329,7 +331,7 @@ public class GraphQLController {
                 throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
             }
             return index;
-        } catch (NumberFormatException e) {
+        } catch (NumberFormatException _) {
             throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Unknown multipart variable path: " + variablePath);
         }
     }
@@ -337,7 +339,7 @@ public class GraphQLController {
     private String partToString(CompletedPart part) {
         try {
             return new String(part.getBytes(), StandardCharsets.UTF_8);
-        } catch (IOException e) {
+        } catch (IOException _) {
             throw new HttpStatusException(UNPROCESSABLE_ENTITY, "Could not process multipart field: " + part.getName());
         }
     }

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationClient.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationClient.groovy
@@ -1,0 +1,12 @@
+package io.micronaut.configuration.graphql
+
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.annotation.Client
+
+@Client("/graphql")
+interface GraphQLContextPropagationClient {
+
+    @Get("{?query}")
+    GraphQLResponseBody hello(@QueryValue String query)
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationFactory.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationFactory.groovy
@@ -1,0 +1,38 @@
+package io.micronaut.configuration.graphql
+
+import graphql.GraphQL
+import graphql.schema.GraphQLSchema
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.io.ResourceResolver
+import jakarta.inject.Singleton
+
+@Factory
+class GraphQLContextPropagationFactory {
+
+    @Bean
+    @Singleton
+    @Requires(property = "spec.name", value = "GraphQLContextPropagationSpec")
+    GraphQL graphQL(ResourceResolver resourceResolver, GraphQLContextPropagationHelloDataFetcher helloDataFetcher) {
+        SchemaParser schemaParser = new SchemaParser()
+        SchemaGenerator schemaGenerator = new SchemaGenerator()
+
+        TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry()
+        typeRegistry.merge(schemaParser.parse(new BufferedReader(new InputStreamReader(
+                resourceResolver.getResourceAsStream("classpath:schema.graphqls").get()))))
+
+        RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                .type("Query", typeWiring -> typeWiring
+                        .dataFetcher("hello", helloDataFetcher))
+                .build()
+
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring)
+
+        GraphQL.newGraphQL(graphQLSchema).build()
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationHelloDataFetcher.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationHelloDataFetcher.groovy
@@ -1,0 +1,25 @@
+package io.micronaut.configuration.graphql
+
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.context.ServerRequestContext
+import jakarta.inject.Singleton
+
+import java.net.http.HttpRequest
+
+@Singleton
+@Requires(property = "spec.name", value = "GraphQLContextPropagationSpec")
+class GraphQLContextPropagationHelloDataFetcher implements DataFetcher<String> {
+
+    @Override
+    String get(DataFetchingEnvironment env) {
+        Optional<HttpRequest> request = ServerRequestContext.currentRequest()
+        assert request.isPresent()
+        String name = env.getArgument("name")
+        if (name == null || name.trim().length() == 0) {
+            name = "World"
+        }
+        String.format("Hello %s!", name)
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLContextPropagationSpec.groovy
@@ -9,8 +9,6 @@ import graphql.schema.idl.SchemaGenerator
 import graphql.schema.idl.SchemaParser
 import graphql.schema.idl.TypeDefinitionRegistry
 import io.micronaut.context.ApplicationContext
-import io.micronaut.context.annotation.Bean
-import io.micronaut.context.annotation.Factory
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.env.Environment
 import io.micronaut.core.annotation.Nullable
@@ -34,13 +32,13 @@ class GraphQLContextPropagationSpec extends Specification {
     @AutoCleanup
     EmbeddedServer embeddedServer
 
-    GraphQLClient graphQLClient
+    GraphQLContextPropagationClient graphQLClient
 
     def setup() {
         embeddedServer = ApplicationContext.run(
                 EmbeddedServer,
                 ["spec.name": GraphQLContextPropagationSpec.simpleName])
-        graphQLClient = embeddedServer.applicationContext.getBean(GraphQLClient)
+        graphQLClient = embeddedServer.applicationContext.getBean(GraphQLContextPropagationClient)
     }
 
     void "server request context is propagated to data fetcher"() {
@@ -52,53 +50,4 @@ class GraphQLContextPropagationSpec extends Specification {
         response.getSpecification()["data"]["hello"] == "Hello World!"
     }
 
-    @Client("/graphql")
-    static interface GraphQLClient {
-
-        @Get("{?query}")
-        GraphQLResponseBody hello(@QueryValue String query)
-
-    }
-
-    @Factory
-    static class GraphQLFactory {
-
-        @Bean
-        @Singleton
-        @Requires(property = "spec.name", value = "GraphQLContextPropagationSpec")
-        GraphQL graphQL(ResourceResolver resourceResolver, HelloDataFetcher helloDataFetcher) {
-
-            SchemaParser schemaParser = new SchemaParser()
-            SchemaGenerator schemaGenerator = new SchemaGenerator()
-
-            TypeDefinitionRegistry typeRegistry = new TypeDefinitionRegistry()
-            typeRegistry.merge(schemaParser.parse(new BufferedReader(new InputStreamReader(
-                    resourceResolver.getResourceAsStream("classpath:schema.graphqls").get()))))
-
-            RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
-                    .type("Query", typeWiring -> typeWiring
-                            .dataFetcher("hello", helloDataFetcher))
-                    .build()
-
-            GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeRegistry, runtimeWiring)
-
-            return GraphQL.newGraphQL(graphQLSchema).build()
-        }
-    }
-
-    @Singleton
-    @Requires(property = "spec.name", value = "GraphQLContextPropagationSpec")
-    static class HelloDataFetcher implements DataFetcher<String> {
-
-        @Override
-        String get(DataFetchingEnvironment env) {
-            Optional<HttpRequest> request = ServerRequestContext.currentRequest()
-            assert request.isPresent()
-            String name = env.getArgument("name")
-            if (name == null || name.trim().length() == 0) {
-                name = "World"
-            }
-            return String.format("Hello %s!", name)
-        }
-    }
 }

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerClient.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerClient.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.configuration.graphql
+
+import io.micronaut.core.annotation.Nullable
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Body
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.annotation.Client
+
+import static io.micronaut.http.MediaType.APPLICATION_GRAPHQL
+import static io.micronaut.http.MediaType.APPLICATION_JSON
+
+@Client("/graphql")
+interface GraphQLControllerClient {
+
+    @Get("{?query,operationName,variables}")
+    GraphQLResponseBody get(@QueryValue String query, @QueryValue @Nullable String operationName, @QueryValue @Nullable String variables)
+
+    @Post(value = "{?query,operationName,variables}")
+    GraphQLResponseBody post(@QueryValue String query, @QueryValue @Nullable String operationName, @QueryValue @Nullable String variables)
+
+    @Post(produces = APPLICATION_JSON)
+    GraphQLResponseBody post(@Body GraphQLRequestBody body)
+
+    @Post(produces = APPLICATION_GRAPHQL)
+    GraphQLResponseBody post(@Body String body)
+
+    @Post(produces = APPLICATION_GRAPHQL)
+    HttpResponse<GraphQLResponseBody> postWithResponse(@Body String body)
+
+    @Post(consumes = APPLICATION_JSON)
+    GraphQLResponseBody postMalformedJson(@Body String body)
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -69,7 +69,7 @@ class GraphQLControllerSpec extends Specification {
     HttpClient httpClient
 
     GraphQL graphQL
-    GraphQLClient graphQLClient
+    GraphQLControllerClient graphQLClient
 
     ExecutionInput executionInput
     String uploadedPartName
@@ -83,15 +83,14 @@ class GraphQLControllerSpec extends Specification {
 
     def setup() {
         graphQL = Mock()
+        GraphQLControllerSpecFactory.graphQL = graphQL
         embeddedServer = ApplicationContext.run(
                 EmbeddedServer,
                 ["spec.name": GraphQLControllerSpec.simpleName],
                 Environment.TEST)
-        embeddedServer.applicationContext.registerSingleton(GraphQL, graphQL)
         httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
-        graphQLClient = embeddedServer.applicationContext.getBean(GraphQLClient)
+        graphQLClient = embeddedServer.applicationContext.getBean(GraphQLControllerClient)
         executionInput = null
-        graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
         uploadedPartName = null
         uploadedFilename = null
         uploadedBytes = null
@@ -547,52 +546,4 @@ class GraphQLControllerSpec extends Specification {
         e.status == HttpStatus.BAD_REQUEST
     }
 
-    @Client("/graphql")
-    static interface GraphQLClient {
-
-        @Get("{?query,operationName,variables}")
-        GraphQLResponseBody get(@QueryValue String query, @QueryValue @Nullable String operationName, @QueryValue @Nullable String variables)
-
-        @Post(value = "{?query,operationName,variables}")
-        GraphQLResponseBody post(@QueryValue String query, @QueryValue @Nullable String operationName, @QueryValue @Nullable String variables)
-
-        @Post(produces = APPLICATION_JSON)
-        GraphQLResponseBody post(@Body GraphQLRequestBody body)
-
-        @Post(produces = APPLICATION_GRAPHQL)
-        GraphQLResponseBody post(@Body String body)
-
-        @Post(produces = APPLICATION_GRAPHQL)
-        HttpResponse<GraphQLResponseBody> postWithResponse(@Body String body)
-
-        @Post(consumes = APPLICATION_JSON)
-        GraphQLResponseBody postMalformedJson(@Body String body)
-
-    }
-
-    @Factory
-    static class GraphQLFactory {
-
-        @Bean
-        @Singleton
-        @Requires(property = "spec.name", value = "GraphQLControllerSpec")
-        GraphQL graphQL() {
-            graphQL
-        }
-    }
-}
-
-@Singleton
-@Primary
-@Requires(property = "spec.name", value = "GraphQLControllerSpec")
-class SetRequestResponseInputCustomizer implements GraphQLExecutionInputCustomizer {
-
-    @Override
-    Publisher<ExecutionInput> customize(ExecutionInput executionInput, HttpRequest httpRequest,
-                                        MutableHttpResponse<String> httpResponse) {
-        GraphQLContext graphQLContext = executionInput.getGraphQLContext();
-        graphQLContext.put("httpRequest", httpRequest);
-        graphQLContext.put("httpResponse", httpResponse);
-        return Publishers.just(executionInput);
-    }
 }

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.HttpClient
-import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.cookie.Cookie
@@ -369,6 +368,54 @@ class GraphQLControllerSpec extends Specification {
         uploadedBytes == "file-body".bytes
     }
 
+    void "test post with multipart form data body accepts string mapping entry"() {
+        given:
+        String query = "mutation (\$input: UploadInput!) { upload(input: \$input) }"
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", """{"query":"${query}","variables":{"input":{"files":[null]}}}""")
+                .addPart("map", '{"0":"variables.input.files.0"}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        GraphQLResponseBody response = httpClient.toBlocking().retrieve(request, GraphQLResponseBody)
+
+        then:
+        response.getSpecification()["data"] == "bar"
+
+        and:
+        executionInput.query == query
+        executionInput.operationName == null
+        executionInput.variables.input.files[0] instanceof CompletedFileUpload
+        executionInput.variables.input.files[0].filename == "upload.txt"
+    }
+
+    void "test post with multipart form data body can map upload into nested object list path"() {
+        given:
+        String query = "mutation (\$input: UploadInput!) { upload(input: \$input) }"
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", """{"query":"${query}","variables":{"input":{"files":[{"attachment":null}]}}}""")
+                .addPart("map", '{"0":["variables.input.files.0.attachment"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        GraphQLResponseBody response = httpClient.toBlocking().retrieve(request, GraphQLResponseBody)
+
+        then:
+        response.getSpecification()["data"] == "bar"
+
+        and:
+        executionInput.query == query
+        executionInput.operationName == null
+        executionInput.variables.input.files[0].attachment instanceof CompletedFileUpload
+        executionInput.variables.input.files[0].attachment.filename == "upload.txt"
+    }
+
     void "test post with multipart form data body requires operations part"() {
         given:
         MultipartBody body = MultipartBody.builder()
@@ -384,6 +431,44 @@ class GraphQLControllerSpec extends Specification {
         HttpClientResponseException e = thrown()
         e.status == HttpStatus.UNPROCESSABLE_ENTITY
         e.response.getBody(String).orElse("").contains("Missing multipart field: operations")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects malformed operations json"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", "{")
+                .addPart("map", '{}')
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.BAD_REQUEST
+        e.response.getBody(String).orElse("").contains("Invalid JSON in GraphQL request body")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects missing mapped file part"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", '{"0":["variables.input.files.0"]}')
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Missing multipart field: 0")
         executionInput == null
     }
 
@@ -447,6 +532,46 @@ class GraphQLControllerSpec extends Specification {
         executionInput == null
     }
 
+    void "test post with multipart form data body rejects non-numeric list index"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", '{"0":["variables.input.files.foo"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Unknown multipart variable path: variables.input.files.foo")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects negative list index"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", '{"0":["variables.input.files.-1"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Unknown multipart variable path: variables.input.files.-1")
+        executionInput == null
+    }
+
     void "test post with multipart form data body requires map part"() {
         given:
         MultipartBody body = MultipartBody.builder()
@@ -462,6 +587,26 @@ class GraphQLControllerSpec extends Specification {
         HttpClientResponseException e = thrown()
         e.status == HttpStatus.UNPROCESSABLE_ENTITY
         e.response.getBody(String).orElse("").contains("Missing multipart field: map")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects malformed map json"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", "{")
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.BAD_REQUEST
+        e.response.getBody(String).orElse("").contains("Invalid JSON in GraphQL variables")
         executionInput == null
     }
 
@@ -485,6 +630,26 @@ class GraphQLControllerSpec extends Specification {
         executionInput == null
     }
 
+    void "test post with multipart form data body rejects missing object variable target"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{}}')
+                .addPart("map", '{"0":["variables.input"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Invalid multipart variable path: variables.input")
+        executionInput == null
+    }
+
     void "test post with multipart form data body rejects non-null variable target"() {
         given:
         MultipartBody body = MultipartBody.builder()
@@ -502,6 +667,46 @@ class GraphQLControllerSpec extends Specification {
         HttpClientResponseException e = thrown()
         e.status == HttpStatus.UNPROCESSABLE_ENTITY
         e.response.getBody(String).orElse("").contains("Invalid multipart variable path: variables.input")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects non-null list variable target"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":["existing"]}}}')
+                .addPart("map", '{"0":["variables.input.files.0"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Invalid multipart variable path: variables.input.files.0")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects nested path through scalar value"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":"existing"}}')
+                .addPart("map", '{"0":["variables.input.file.name"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Unknown multipart variable path: variables.input.file.name")
         executionInput == null
     }
 

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -470,7 +470,8 @@ class GraphQLControllerSpec extends Specification {
         given:
         MultipartBody body = MultipartBody.builder()
                 .addPart("operations", '{"query":"","variables":{"input":null}}')
-                .addPart("map", '{"operations":["variables.input"]}')
+                .addPart("map", '{"textField":["variables.input"]}')
+                .addPart("textField", "not a file")
                 .build()
         HttpRequest<?> request = HttpRequest.POST("/graphql", body)
                 .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
@@ -481,7 +482,7 @@ class GraphQLControllerSpec extends Specification {
         then:
         HttpClientResponseException e = thrown()
         e.status == HttpStatus.UNPROCESSABLE_ENTITY
-        e.response.getBody(String).orElse("").contains("Multipart field is not a file upload: operations")
+        e.response.getBody(String).orElse("").contains("Multipart field is not a file upload: textField")
         executionInput == null
     }
 

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -40,6 +40,7 @@ import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.cookie.Cookie
@@ -317,6 +318,27 @@ class GraphQLControllerSpec extends Specification {
         uploadedBytes == "file-body".bytes
     }
 
+    void "test post with multipart form data body defaults null query and variables"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":null,"variables":null}')
+                .addPart("map", '{}')
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        GraphQLResponseBody response = httpClient.toBlocking().retrieve(request, GraphQLResponseBody)
+
+        then:
+        response.getSpecification()["data"] == "bar"
+
+        and:
+        executionInput.query == ""
+        executionInput.operationName == null
+        executionInput.variables == [:]
+    }
+
     void "test post with multipart form data body can map one upload to multiple variables"() {
         given:
         String query = "mutation (\$input: UploadInput!) { upload(input: \$input) }"
@@ -346,6 +368,84 @@ class GraphQLControllerSpec extends Specification {
         uploadedPartName == "0"
         uploadedFilename == "upload.txt"
         uploadedBytes == "file-body".bytes
+    }
+
+    void "test post with multipart form data body requires operations part"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("map", '{}')
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Missing multipart field: operations")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects invalid mapping payload"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", '{"0":[1]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Invalid multipart mapping payload")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects unsupported variable path"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", '{"0":["input.files.0"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Unsupported multipart variable path: input.files.0")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects unknown list index"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":{"files":[null]}}}')
+                .addPart("map", '{"0":["variables.input.files.1"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Unknown multipart variable path: variables.input.files.1")
+        executionInput == null
     }
 
     void "test additional headers and cookies"() {

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -448,6 +448,63 @@ class GraphQLControllerSpec extends Specification {
         executionInput == null
     }
 
+    void "test post with multipart form data body requires map part"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{}}')
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Missing multipart field: map")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects non-file upload parts"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":null}}')
+                .addPart("map", '{"operations":["variables.input"]}')
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Multipart field is not a file upload: operations")
+        executionInput == null
+    }
+
+    void "test post with multipart form data body rejects non-null variable target"() {
+        given:
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", '{"query":"","variables":{"input":"existing"}}')
+                .addPart("map", '{"0":["variables.input"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        httpClient.toBlocking().exchange(request, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        e.status == HttpStatus.UNPROCESSABLE_ENTITY
+        e.response.getBody(String).orElse("").contains("Invalid multipart variable path: variables.input")
+        executionInput == null
+    }
+
     void "test additional headers and cookies"() {
         given:
         String body = "{ testHeaders }"

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -21,6 +21,10 @@ import graphql.ExecutionResult
 import graphql.ExecutionResultImpl
 import graphql.GraphQL
 import graphql.GraphQLContext
+import graphql.Scalars
+import graphql.schema.GraphQLFieldDefinition
+import graphql.schema.GraphQLObjectType
+import graphql.schema.GraphQLSchema
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Bean
 import io.micronaut.context.annotation.Factory
@@ -82,6 +86,16 @@ class GraphQLControllerSpec extends Specification {
 
     def setup() {
         graphQL = Mock()
+        graphQL.getGraphQLSchema() >> GraphQLSchema.newSchema()
+                .query(GraphQLObjectType.newObject()
+                        .name("Query")
+                        .field(GraphQLFieldDefinition.newFieldDefinition()
+                                .name("foo")
+                                .type(Scalars.GraphQLString)
+                                .build())
+                        .build())
+                .build()
+        graphQL.transform(_) >> graphQL
         GraphQLControllerSpecFactory.graphQL = graphQL
         embeddedServer = ApplicationContext.run(
                 EmbeddedServer,

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -33,13 +33,17 @@ import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.http.MediaType
 import io.micronaut.http.MutableHttpResponse
 import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
 import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.multipart.MultipartBody
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.cookie.Cookie
+import io.micronaut.http.multipart.CompletedFileUpload
 import io.micronaut.runtime.server.EmbeddedServer
 import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
@@ -60,10 +64,16 @@ class GraphQLControllerSpec extends Specification {
     @AutoCleanup
     EmbeddedServer embeddedServer
 
+    @AutoCleanup
+    HttpClient httpClient
+
     GraphQL graphQL
     GraphQLClient graphQLClient
 
     ExecutionInput executionInput
+    String uploadedPartName
+    String uploadedFilename
+    byte[] uploadedBytes
 
     CompletableFuture<ExecutionResult> executionResult = CompletableFuture.completedFuture(
             ExecutionResultImpl.newExecutionResult()
@@ -77,10 +87,22 @@ class GraphQLControllerSpec extends Specification {
                 ["spec.name": GraphQLControllerSpec.simpleName],
                 Environment.TEST)
         embeddedServer.applicationContext.registerSingleton(GraphQL, graphQL)
+        httpClient = embeddedServer.applicationContext.createBean(HttpClient, embeddedServer.getURL())
         graphQLClient = embeddedServer.applicationContext.getBean(GraphQLClient)
         executionInput = null
         graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
+        uploadedPartName = null
+        uploadedFilename = null
+        uploadedBytes = null
+        graphQL.executeAsync(_) >> { ExecutionInput executionInput ->
             this.executionInput = executionInput
+            def uploadedFiles = executionInput.variables?.input?.files
+            if (uploadedFiles instanceof List && uploadedFiles[0] instanceof CompletedFileUpload) {
+                CompletedFileUpload file = uploadedFiles[0] as CompletedFileUpload
+                uploadedPartName = file.name
+                uploadedFilename = file.filename
+                uploadedBytes = file.bytes
+            }
             if (executionInput.query == "{ testHeaders }") {
                 GraphQLContext graphQlContext = executionInput.getGraphQLContext()
 
@@ -265,6 +287,65 @@ class GraphQLControllerSpec extends Specification {
         executionInput.query == body
         executionInput.operationName == null
         executionInput.variables == [:]
+    }
+
+    void "test post with multipart form data body"() {
+        given:
+        String query = "mutation (\$input: UploadInput!) { upload(input: \$input) }"
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", """{"query":"${query}","variables":{"input":{"files":[null]}}}""")
+                .addPart("map", '{"0":["variables.input.files.0"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        GraphQLResponseBody response = httpClient.toBlocking().retrieve(request, GraphQLResponseBody)
+
+        then:
+        response.getSpecification()["data"] == "bar"
+
+        and:
+        executionInput.query == query
+        executionInput.operationName == null
+        executionInput.variables.input.files[0] instanceof CompletedFileUpload
+
+        and:
+        uploadedPartName == "0"
+        uploadedFilename == "upload.txt"
+        uploadedBytes == "file-body".bytes
+    }
+
+    void "test post with multipart form data body can map one upload to multiple variables"() {
+        given:
+        String query = "mutation (\$input: UploadInput!) { upload(input: \$input) }"
+        MultipartBody body = MultipartBody.builder()
+                .addPart("operations", """{"query":"${query}","variables":{"input":{"files":[null,null]}}}""")
+                .addPart("map", '{"0":["variables.input.files.0","variables.input.files.1"]}')
+                .addPart("0", "upload.txt", MediaType.TEXT_PLAIN_TYPE, "file-body".bytes)
+                .build()
+        HttpRequest<?> request = HttpRequest.POST("/graphql", body)
+                .contentType(MediaType.MULTIPART_FORM_DATA_TYPE)
+
+        when:
+        GraphQLResponseBody response = httpClient.toBlocking().retrieve(request, GraphQLResponseBody)
+
+        then:
+        response.getSpecification()["data"] == "bar"
+
+        and:
+        executionInput.query == query
+        executionInput.operationName == null
+        executionInput.variables.input.files[0] instanceof CompletedFileUpload
+        executionInput.variables.input.files[1] instanceof CompletedFileUpload
+        executionInput.variables.input.files[0].filename == "upload.txt"
+        executionInput.variables.input.files[1].filename == "upload.txt"
+
+        and:
+        uploadedPartName == "0"
+        uploadedFilename == "upload.txt"
+        uploadedBytes == "file-body".bytes
     }
 
     void "test additional headers and cookies"() {

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpec.groovy
@@ -36,7 +36,6 @@ import io.micronaut.core.async.publisher.Publishers
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
-import io.micronaut.http.MediaType
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import io.micronaut.http.MediaType
 import io.micronaut.http.MutableHttpResponse

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpecFactory.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLControllerSpecFactory.groovy
@@ -1,0 +1,21 @@
+package io.micronaut.configuration.graphql
+
+import graphql.GraphQL
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+
+@Factory
+class GraphQLControllerSpecFactory {
+
+    static GraphQL graphQL
+
+    @Bean
+    @Singleton
+    @Requires(property = "spec.name", value = "GraphQLControllerSpec")
+    GraphQL graphQL() {
+        assert graphQL != null
+        graphQL
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/SetRequestResponseInputCustomizer.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/SetRequestResponseInputCustomizer.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.configuration.graphql
+
+import graphql.ExecutionInput
+import graphql.GraphQLContext
+import io.micronaut.context.annotation.Primary
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.async.publisher.Publishers
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MutableHttpResponse
+import jakarta.inject.Singleton
+import org.reactivestreams.Publisher
+
+@Singleton
+@Primary
+@Requires(property = "spec.name", value = "GraphQLControllerSpec")
+class SetRequestResponseInputCustomizer implements GraphQLExecutionInputCustomizer {
+
+    @Override
+    Publisher<ExecutionInput> customize(ExecutionInput executionInput, HttpRequest httpRequest,
+                                        MutableHttpResponse<String> httpResponse) {
+        GraphQLContext graphQLContext = executionInput.getGraphQLContext()
+        graphQLContext.put("httpRequest", httpRequest)
+        graphQLContext.put("httpResponse", httpResponse)
+        return Publishers.just(executionInput)
+    }
+}

--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -9,6 +9,7 @@ As outlined in https://graphql.org/learn/serving-over-http the following HTTP re
 
 * `GET` request with `query`, `operationName` and `variables` query parameters. The `variables` query parameter must be json encoded.
 * `POST` request with `application/json` body and keys `query` (String), `operationName` (String) and `variables` (Map).
+* `POST` request with `multipart/form-data` body using the https://github.com/jaydenseric/graphql-multipart-request-spec[GraphQL multipart request specification].
 
 Both produce a `application/json` response.
 

--- a/src/main/docs/guide/configuration/multipart.adoc
+++ b/src/main/docs/guide/configuration/multipart.adoc
@@ -1,0 +1,38 @@
+GraphQL multipart requests can be sent to the configured GraphQL endpoint using `multipart/form-data`
+following the https://github.com/jaydenseric/graphql-multipart-request-spec[GraphQL multipart request specification].
+
+Micronaut GraphQL expects the multipart request to contain:
+
+* an `operations` part with the GraphQL request payload as JSON
+* a `map` part describing which uploaded file part is injected into which GraphQL variables path
+* one or more file parts referenced by the `map`
+
+Uploaded files are exposed to GraphQL as Micronaut
+https://docs.micronaut.io/latest/api/io/micronaut/http/multipart/CompletedFileUpload.html[CompletedFileUpload]
+instances, so your GraphQL schema and runtime wiring must provide a compatible `Upload` scalar that accepts
+`CompletedFileUpload` values.
+
+[source,graphql]
+----
+scalar Upload
+
+input UploadInput {
+  files: [Upload!]!
+}
+
+type Mutation {
+  upload(input: UploadInput!): Boolean!
+}
+----
+
+After registering an `Upload` scalar, a multipart upload can be sent like this:
+
+[source,bash]
+----
+curl "$MICRONAUT_URL/graphql" \
+  -F 'operations={"query":"mutation ($input: UploadInput!) { upload(input: $input) }","variables":{"input":{"files":[null]}}}' \
+  -F 'map={"0":["variables.input.files.0"]}' \
+  -F '0=@upload.txt;type=text/plain'
+----
+
+The GraphQL data fetcher can then read the injected upload from the variables as a `CompletedFileUpload`.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -5,6 +5,7 @@ quickStart: Quick Start
 configuration:
   title: Configuration
   graphql-bean: Configuring the GraphQL Bean
+  multipart: GraphQL Multipart Requests
   graphql-ws: Configuring GraphQL over websockets
   graphiql: Configuring GraphiQL
   jackson: Notes on using Jackson serialization


### PR DESCRIPTION
Adds multipart/form-data support for GraphQL POST requests following the GraphQL multipart request spec.

Includes controller coverage for single-file and multi-mapped upload requests, plus guide documentation for configuring Upload handling.

Supersedes #599.

Resolves #12