### PR TITLE
Fix null GraphQL fields in native images

### DIFF
--- a/buildSrc/src/main/groovy/micronaut-graphql.example-conventions.gradle
+++ b/buildSrc/src/main/groovy/micronaut-graphql.example-conventions.gradle
@@ -15,9 +15,12 @@ dependencies {
     implementation mn.micronaut.jackson.databind
     implementation mn.micronaut.runtime
 
+    testImplementation mnTest.micronaut.test.junit5
     runtimeOnly mnLogging.logback.classic
     runtimeOnly mn.snakeyaml
 
+    testRuntimeOnly mnTest.junit.jupiter.engine
+    testRuntimeOnly mnTest.junit.platform.launcher
     testRuntimeOnly mn.snakeyaml
 }
 
@@ -29,4 +32,8 @@ micronaut {
     version.set(libs.versions.micronaut.platform.get())
     coreVersion.set(libs.versions.micronaut.asProvider().get())
     runtime("netty")
+}
+
+tasks.named("test") {
+    useJUnitPlatform()
 }

--- a/examples/todo-java-tools/src/main/java/example/graphql/GraphQLFactory.java
+++ b/examples/todo-java-tools/src/main/java/example/graphql/GraphQLFactory.java
@@ -15,18 +15,31 @@
  */
 package example.graphql;
 
+import example.domain.Author;
+import example.domain.ToDo;
 import graphql.GraphQL;
 import graphql.kickstart.tools.SchemaParser;
 import graphql.kickstart.tools.SchemaParserBuilder;
 import graphql.schema.GraphQLSchema;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
+import io.micronaut.core.annotation.TypeHint;
 import jakarta.inject.Singleton;
 
 /**
  * @author Marcel Overdijk
  */
 @Factory
+@TypeHint(
+    value = {
+        Author.class,
+        ToDo.class,
+        ToDoMutationResolver.class,
+        ToDoQueryResolver.class,
+        ToDoResolver.class
+    },
+    accessType = TypeHint.AccessType.ALL_DECLARED_METHODS
+)
 public class GraphQLFactory {
 
     @Bean

--- a/examples/todo-java-tools/src/test/java/example/ToDoGraphQLTest.java
+++ b/examples/todo-java-tools/src/test/java/example/ToDoGraphQLTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+public class ToDoGraphQLTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    public void queryToDosResolvesNestedAuthorInNativeCompatiblePath() {
+        Map<String, Object> result = execute("{ toDos { id title completed author { id username } } }");
+
+        Map<String, Object> data = data(result);
+        List<Map<String, Object>> toDos = (List<Map<String, Object>>) data.get("toDos");
+        assertNotNull(toDos);
+        assertFalse(toDos.isEmpty());
+
+        Map<String, Object> firstToDo = toDos.getFirst();
+        assertNotNull(firstToDo.get("id"));
+        assertNotNull(firstToDo.get("title"));
+        assertNotNull(firstToDo.get("completed"));
+
+        Map<String, Object> author = (Map<String, Object>) firstToDo.get("author");
+        assertNotNull(author);
+        assertNotNull(author.get("id"));
+        assertNotNull(author.get("username"));
+    }
+
+    @Test
+    public void mutationCreateToDoResolvesNestedAuthorInNativeCompatiblePath() {
+        Map<String, Object> result = execute(
+            "mutation { createToDo(title:\"demo-pr\", author:\"alice\") { id title completed author { id username } } }"
+        );
+
+        Map<String, Object> data = data(result);
+        Map<String, Object> toDo = (Map<String, Object>) data.get("createToDo");
+        assertNotNull(toDo);
+        assertEquals("demo-pr", toDo.get("title"));
+        assertEquals(Boolean.FALSE, toDo.get("completed"));
+
+        Map<String, Object> author = (Map<String, Object>) toDo.get("author");
+        assertNotNull(author);
+        assertEquals("alice", author.get("username"));
+        assertNotNull(author.get("id"));
+    }
+
+    private Map<String, Object> execute(String query) {
+        Map<String, Object> result = client.toBlocking().retrieve(
+            HttpRequest.POST("/graphql", Map.of("query", query)),
+            Map.class
+        );
+        assertNotNull(result);
+        assertFalse(result.containsKey("errors"));
+        return result;
+    }
+
+    private Map<String, Object> data(Map<String, Object> result) {
+        assertTrue(result.containsKey("data"));
+        return (Map<String, Object>) result.get("data");
+    }
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLBeanCreatedEventListener.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLBeanCreatedEventListener.java
@@ -46,9 +46,7 @@ final class GraphQLBeanCreatedEventListener implements BeanCreatedEventListener<
     }
 
     private boolean usesSingletonPropertyDataFetcher(GraphQLCodeRegistry codeRegistry) {
-        final boolean[] usesSingleton = new boolean[1];
-        codeRegistry.transform(builder -> usesSingleton[0] =
-                builder.getDefaultDataFetcherFactory() == SingletonPropertyDataFetcher.singletonFactory());
-        return usesSingleton[0];
+        return GraphQLCodeRegistry.newCodeRegistry(codeRegistry).getDefaultDataFetcherFactory()
+                == SingletonPropertyDataFetcher.singletonFactory();
     }
 }

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLBeanCreatedEventListener.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLBeanCreatedEventListener.java
@@ -39,9 +39,8 @@ final class GraphQLBeanCreatedEventListener implements BeanCreatedEventListener<
         if (!usesSingletonPropertyDataFetcher(graphQLSchema.getCodeRegistry())) {
             return graphQL;
         }
-        GraphQLCodeRegistry codeRegistry = graphQLSchema.getCodeRegistry().transform(builder -> {
-            builder.defaultDataFetcher(MicronautBeanPropertyDataFetcher.factory());
-        });
+        GraphQLCodeRegistry codeRegistry = graphQLSchema.getCodeRegistry().transform(builder ->
+                builder.defaultDataFetcher(MicronautBeanPropertyDataFetcher.factory()));
         GraphQLSchema updatedSchema = graphQLSchema.transform(builder -> builder.codeRegistry(codeRegistry));
         return graphQL.transform(builder -> builder.schema(updatedSchema));
     }

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLBeanCreatedEventListener.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLBeanCreatedEventListener.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql;
+
+import graphql.GraphQL;
+import graphql.schema.GraphQLCodeRegistry;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.SingletonPropertyDataFetcher;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import jakarta.inject.Singleton;
+
+/**
+ * Replaces GraphQL Java's reflective default property fetcher with a Micronaut
+ * introspection-aware variant while preserving explicit data fetchers.
+ *
+ * @since 1.0
+ */
+@Singleton
+final class GraphQLBeanCreatedEventListener implements BeanCreatedEventListener<GraphQL> {
+
+    @Override
+    public GraphQL onCreated(BeanCreatedEvent<GraphQL> event) {
+        GraphQL graphQL = event.getBean();
+        GraphQLSchema graphQLSchema = graphQL.getGraphQLSchema();
+        if (!usesSingletonPropertyDataFetcher(graphQLSchema.getCodeRegistry())) {
+            return graphQL;
+        }
+        GraphQLCodeRegistry codeRegistry = graphQLSchema.getCodeRegistry().transform(builder -> {
+            builder.defaultDataFetcher(MicronautBeanPropertyDataFetcher.factory());
+        });
+        GraphQLSchema updatedSchema = graphQLSchema.transform(builder -> builder.codeRegistry(codeRegistry));
+        return graphQL.transform(builder -> builder.schema(updatedSchema));
+    }
+
+    private boolean usesSingletonPropertyDataFetcher(GraphQLCodeRegistry codeRegistry) {
+        final boolean[] usesSingleton = new boolean[1];
+        codeRegistry.transform(builder -> usesSingleton[0] =
+                builder.getDefaultDataFetcherFactory() == SingletonPropertyDataFetcher.singletonFactory());
+        return usesSingleton[0];
+    }
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/MicronautBeanPropertyDataFetcher.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/MicronautBeanPropertyDataFetcher.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetcherFactory;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.LightDataFetcher;
+import graphql.schema.PropertyDataFetcher;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.core.beans.BeanProperty;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A GraphQL data fetcher that prefers Micronaut bean introspection before
+ * falling back to GraphQL Java's reflective property lookup.
+ *
+ * @param <T> The fetched type
+ * @since 1.0
+ */
+final class MicronautBeanPropertyDataFetcher<T> implements LightDataFetcher<T> {
+
+    private static final MicronautBeanPropertyDataFetcher<Object> INSTANCE = new MicronautBeanPropertyDataFetcher<>();
+    private static final DataFetcherFactory<?> FACTORY = environment -> INSTANCE;
+
+    private MicronautBeanPropertyDataFetcher() {
+    }
+
+    static DataFetcherFactory<?> factory() {
+        return FACTORY;
+    }
+
+    @Override
+    public T get(GraphQLFieldDefinition fieldDefinition, Object source, Supplier<DataFetchingEnvironment> environmentSupplier) throws Exception {
+        if (source == null) {
+            return null;
+        }
+        String propertyName = fieldDefinition.getName();
+        PropertyLookup propertyValue = readProperty(propertyName, source);
+        if (propertyValue.resolved()) {
+            return (T) propertyValue.value();
+        }
+        return (T) PropertyDataFetcher.fetching(propertyName).get(fieldDefinition, source, environmentSupplier);
+    }
+
+    @Override
+    public T get(DataFetchingEnvironment environment) throws Exception {
+        return get(environment.getFieldDefinition(), environment.getSource(), () -> environment);
+    }
+
+    private PropertyLookup readProperty(String propertyName, Object source) {
+        if (source instanceof Map<?, ?> map) {
+            return map.containsKey(propertyName) ? PropertyLookup.resolved(map.get(propertyName)) : PropertyLookup.unresolved();
+        }
+        return BeanIntrospector.SHARED.findIntrospection(source.getClass())
+                .map(introspection -> readIntrospectedProperty(introspection, source, propertyName))
+                .orElse(PropertyLookup.unresolved());
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private PropertyLookup readIntrospectedProperty(BeanIntrospection introspection, Object source, String propertyName) {
+        Object property = introspection.getProperty(propertyName).orElse(null);
+        if (property == null) {
+            return PropertyLookup.unresolved();
+        }
+        return PropertyLookup.resolved(((BeanProperty) property).get(source));
+    }
+
+    private record PropertyLookup(boolean resolved, Object value) {
+
+        private static PropertyLookup resolved(Object value) {
+            return new PropertyLookup(true, value);
+        }
+
+        private static PropertyLookup unresolved() {
+            return new PropertyLookup(false, null);
+        }
+    }
+}

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/MicronautBeanPropertyDataFetcher.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/MicronautBeanPropertyDataFetcher.java
@@ -22,7 +22,6 @@ import graphql.schema.LightDataFetcher;
 import graphql.schema.PropertyDataFetcher;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanIntrospector;
-import io.micronaut.core.beans.BeanProperty;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -73,13 +72,10 @@ final class MicronautBeanPropertyDataFetcher<T> implements LightDataFetcher<T> {
                 .orElse(PropertyLookup.unresolved());
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    private PropertyLookup readIntrospectedProperty(BeanIntrospection introspection, Object source, String propertyName) {
-        Object property = introspection.getProperty(propertyName).orElse(null);
-        if (property == null) {
-            return PropertyLookup.unresolved();
-        }
-        return PropertyLookup.resolved(((BeanProperty) property).get(source));
+    private <B> PropertyLookup readIntrospectedProperty(BeanIntrospection<B> introspection, Object source, String propertyName) {
+        return introspection.getProperty(propertyName)
+                .map(property -> PropertyLookup.resolved(property.get(introspection.getBeanType().cast(source))))
+                .orElseGet(PropertyLookup::unresolved);
     }
 
     private record PropertyLookup(boolean resolved, Object value) {

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/MicronautBeanPropertyDataFetcher.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/MicronautBeanPropertyDataFetcher.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.configuration.graphql;
 
-import graphql.schema.DataFetcher;
 import graphql.schema.DataFetcherFactory;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLFieldDefinition;
@@ -38,12 +37,12 @@ import java.util.function.Supplier;
 final class MicronautBeanPropertyDataFetcher<T> implements LightDataFetcher<T> {
 
     private static final MicronautBeanPropertyDataFetcher<Object> INSTANCE = new MicronautBeanPropertyDataFetcher<>();
-    private static final DataFetcherFactory<?> FACTORY = environment -> INSTANCE;
+    private static final DataFetcherFactory<Object> FACTORY = environment -> INSTANCE;
 
     private MicronautBeanPropertyDataFetcher() {
     }
 
-    static DataFetcherFactory<?> factory() {
+    static DataFetcherFactory<Object> factory() {
         return FACTORY;
     }
 

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLCustomDefaultDataFetcherSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLCustomDefaultDataFetcherSpec.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql
+
+import graphql.ExecutionInput
+import graphql.GraphQL
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetcherFactory
+import graphql.schema.GraphQLSchema
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class GraphQLCustomDefaultDataFetcherSpec extends Specification {
+
+    @AutoCleanup
+    ApplicationContext applicationContext = ApplicationContext.run(
+            ["spec.name": GraphQLCustomDefaultDataFetcherSpec.simpleName],
+            Environment.TEST)
+
+    void "custom default data fetcher is preserved"() {
+        given:
+        GraphQL graphQL = applicationContext.getBean(GraphQL)
+
+        when:
+        def result = graphQL.execute(ExecutionInput.newExecutionInput("query { book { name } }").build())
+        def bookType = graphQL.graphQLSchema.getObjectType("Book")
+        def nameField = bookType.getFieldDefinition("name")
+
+        then:
+        result.toSpecification()["data"]["book"]["name"] == "custom default"
+        graphQL.graphQLSchema.codeRegistry.getDataFetcher(bookType, nameField) instanceof CustomDefaultDataFetcher
+    }
+
+    @Factory
+    static class GraphQLFactory {
+
+        @Bean
+        @Singleton
+        @Requires(property = "spec.name", value = "GraphQLCustomDefaultDataFetcherSpec")
+        GraphQL graphQL(BookDataFetcher bookDataFetcher) {
+            TypeDefinitionRegistry typeRegistry = new SchemaParser().parse("""
+                type Query {
+                    book: Book
+                }
+
+                type Book {
+                    name: String
+                }
+            """)
+
+            RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                    .type("Query", typeWiring -> typeWiring.dataFetcher("book", bookDataFetcher))
+                    .build()
+
+            GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(typeRegistry, runtimeWiring)
+            graphQLSchema = graphQLSchema.transform(builder -> builder.codeRegistry(
+                    graphQLSchema.codeRegistry.transform(codeRegistryBuilder ->
+                            codeRegistryBuilder.defaultDataFetcher(CustomDefaultDataFetcher.factory()))
+            ))
+            return GraphQL.newGraphQL(graphQLSchema).build()
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "GraphQLCustomDefaultDataFetcherSpec")
+    static class BookDataFetcher implements DataFetcher<Book> {
+
+        @Override
+        Book get(graphql.schema.DataFetchingEnvironment environment) {
+            return new Book("Micronaut GraphQL")
+        }
+    }
+
+    static class CustomDefaultDataFetcher implements DataFetcher<Object> {
+        private static final CustomDefaultDataFetcher INSTANCE = new CustomDefaultDataFetcher()
+        private static final DataFetcherFactory<?> FACTORY = environment -> INSTANCE
+
+        static DataFetcherFactory<?> factory() {
+            return FACTORY
+        }
+
+        @Override
+        Object get(graphql.schema.DataFetchingEnvironment environment) {
+            return "custom default"
+        }
+    }
+
+    static class Book {
+        final String name
+
+        Book(String name) {
+            this.name = name
+        }
+    }
+}

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLIntrospectionPropertyDataFetcherSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLIntrospectionPropertyDataFetcherSpec.groovy
@@ -15,8 +15,12 @@
  */
 package io.micronaut.configuration.graphql
 
+import graphql.Scalars
 import graphql.GraphQL
 import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import graphql.schema.DataFetcherFactoryEnvironment
+import graphql.schema.GraphQLFieldDefinition
 import graphql.schema.GraphQLSchema
 import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaGenerator
@@ -75,6 +79,55 @@ class GraphQLIntrospectionPropertyDataFetcherSpec extends Specification {
         graphQL.graphQLSchema.codeRegistry.getDataFetcher(bookType, nameField) instanceof MicronautBeanPropertyDataFetcher
     }
 
+    void "null sources return null"() {
+        given:
+        def dataFetcher = dataFetcher()
+
+        expect:
+        dataFetcher.get(fieldDefinition("name"), null, { null }) == null
+    }
+
+    void "map sources preserve null values and missing keys return null"() {
+        given:
+        def dataFetcher = dataFetcher()
+
+        expect:
+        dataFetcher.get(fieldDefinition("name"), [name: null], { null }) == null
+        dataFetcher.get(fieldDefinition("name"), [:], { null }) == null
+    }
+
+    void "data fetching environment overload falls back to reflective property lookup"() {
+        given:
+        def dataFetcher = dataFetcher()
+        def environment = Stub(DataFetchingEnvironment) {
+            getFieldDefinition() >> fieldDefinition("name")
+            getSource() >> new LegacyBook("Micronaut GraphQL")
+        }
+
+        expect:
+        dataFetcher.get(environment) == "Micronaut GraphQL"
+    }
+
+    void "missing introspected properties return null"() {
+        given:
+        def dataFetcher = dataFetcher()
+
+        expect:
+        dataFetcher.get(fieldDefinition("name"), new TitleOnlyBook("Micronaut GraphQL"), { null }) == null
+    }
+
+    private static GraphQLFieldDefinition fieldDefinition(String name) {
+        GraphQLFieldDefinition.newFieldDefinition()
+                .name(name)
+                .type(Scalars.GraphQLString)
+                .build()
+    }
+
+    private static MicronautBeanPropertyDataFetcher<Object> dataFetcher() {
+        (MicronautBeanPropertyDataFetcher<Object>) MicronautBeanPropertyDataFetcher.factory()
+                .get((DataFetcherFactoryEnvironment) null)
+    }
+
     @Client("/graphql")
     static interface GraphQLClient {
 
@@ -127,6 +180,27 @@ class GraphQLIntrospectionPropertyDataFetcherSpec extends Specification {
 
         Book(String name) {
             this.name = name
+        }
+    }
+
+    static class LegacyBook {
+        private final String name
+
+        LegacyBook(String name) {
+            this.name = name
+        }
+
+        String getName() {
+            return name
+        }
+    }
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD)
+    static class TitleOnlyBook {
+        private final String title
+
+        TitleOnlyBook(String title) {
+            this.title = title
         }
     }
 }

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLIntrospectionPropertyDataFetcherSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/GraphQLIntrospectionPropertyDataFetcherSpec.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.graphql
+
+import graphql.GraphQL
+import graphql.schema.DataFetcher
+import graphql.schema.GraphQLSchema
+import graphql.schema.idl.RuntimeWiring
+import graphql.schema.idl.SchemaGenerator
+import graphql.schema.idl.SchemaParser
+import graphql.schema.idl.TypeDefinitionRegistry
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.core.annotation.Introspected
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.runtime.server.EmbeddedServer
+import jakarta.inject.Singleton
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+
+class GraphQLIntrospectionPropertyDataFetcherSpec extends Specification {
+
+    @AutoCleanup
+    EmbeddedServer embeddedServer
+
+    GraphQLClient graphQLClient
+    GraphQL graphQL
+
+    def setup() {
+        embeddedServer = ApplicationContext.run(
+                EmbeddedServer,
+                ["spec.name": GraphQLIntrospectionPropertyDataFetcherSpec.simpleName],
+                Environment.TEST)
+        graphQLClient = embeddedServer.applicationContext.getBean(GraphQLClient)
+        graphQL = embeddedServer.applicationContext.getBean(GraphQL)
+    }
+
+    void "introspected fields are resolved without reflection metadata"() {
+        when:
+        GraphQLResponseBody response = graphQLClient.book("query { book { name } }")
+        def bookType = graphQL.graphQLSchema.getObjectType("Book")
+        def nameField = bookType.getFieldDefinition("name")
+
+        then:
+        response.getSpecification()["data"]["book"]["name"] == "Micronaut GraphQL"
+        graphQL.graphQLSchema.codeRegistry.getDataFetcher(bookType, nameField) instanceof MicronautBeanPropertyDataFetcher
+    }
+
+    void "null introspected fields do not fall back to reflection"() {
+        when:
+        GraphQLResponseBody response = graphQLClient.book("query { nullBook { name } }")
+        def bookType = graphQL.graphQLSchema.getObjectType("Book")
+        def nameField = bookType.getFieldDefinition("name")
+
+        then:
+        response.getSpecification()["data"]["nullBook"]["name"] == null
+        graphQL.graphQLSchema.codeRegistry.getDataFetcher(bookType, nameField) instanceof MicronautBeanPropertyDataFetcher
+    }
+
+    @Client("/graphql")
+    static interface GraphQLClient {
+
+        @Get("{?query}")
+        GraphQLResponseBody book(@QueryValue String query)
+    }
+
+    @Factory
+    static class GraphQLFactory {
+
+        @Bean
+        @Singleton
+        @Requires(property = "spec.name", value = "GraphQLIntrospectionPropertyDataFetcherSpec")
+        GraphQL graphQL(BookDataFetcher bookDataFetcher) {
+            TypeDefinitionRegistry typeRegistry = new SchemaParser().parse("""
+                type Query {
+                    book: Book
+                    nullBook: Book
+                }
+
+                type Book {
+                    name: String
+                }
+            """)
+
+            RuntimeWiring runtimeWiring = RuntimeWiring.newRuntimeWiring()
+                    .type("Query", typeWiring -> typeWiring
+                            .dataFetcher("book", bookDataFetcher)
+                            .dataFetcher("nullBook", bookDataFetcher))
+                    .build()
+
+            GraphQLSchema graphQLSchema = new SchemaGenerator().makeExecutableSchema(typeRegistry, runtimeWiring)
+            return GraphQL.newGraphQL(graphQLSchema).build()
+        }
+    }
+
+    @Singleton
+    @Requires(property = "spec.name", value = "GraphQLIntrospectionPropertyDataFetcherSpec")
+    static class BookDataFetcher implements DataFetcher<Book> {
+
+        @Override
+        Book get(graphql.schema.DataFetchingEnvironment environment) {
+            return environment.field.name == "nullBook" ? new Book(null) : new Book("Micronaut GraphQL")
+        }
+    }
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD)
+    static class Book {
+        private final String name
+
+        Book(String name) {
+            this.name = name
+        }
+    }
+}

--- a/src/main/docs/guide/configuration.adoc
+++ b/src/main/docs/guide/configuration.adoc
@@ -25,3 +25,5 @@ graphql:
 <2> Configures the GraphQL endpoint path. Default `/graphql`.
 
 You only must configure a bean of type `graphql.GraphQL` containing the GraphQL schema and runtime wiring.
+
+When GraphQL Java resolves nested fields through its default property lookup, Micronaut GraphQL first uses Micronaut bean introspection before falling back to GraphQL Java's default behavior. This means `@Introspected` result types work without additional reflection metadata in native image builds, while applications with a custom GraphQL Java default data fetcher keep their existing behavior.

--- a/src/main/docs/guide/configuration/graphql-bean.adoc
+++ b/src/main/docs/guide/configuration/graphql-bean.adoc
@@ -12,5 +12,7 @@ snippet::io.micronaut.graphql.docs.GraphQLFactory[tags="imports,clazz", project-
 <1> Define the `Factory` annotation to create the bean.
 <2> Define the `GraphQL` bean which contains the runtime wiring and the executable schema.
 
+If a schema field relies on GraphQL Java's default property resolution instead of an explicit `DataFetcher`, Micronaut GraphQL uses Micronaut bean introspection before falling back to GraphQL Java's default property fetcher. For native image applications, annotate returned domain types with `@Introspected` so nested properties can be resolved without additional reflection metadata. If you have configured a custom GraphQL Java default data fetcher, Micronaut GraphQL preserves that custom configuration.
+
 There are various https://github.com/micronaut-projects/micronaut-graphql/tree/master/examples[examples] using different technologies
 provided in the repository.


### PR DESCRIPTION
## Summary
- replace GraphQL Java's default reflective property fetcher with a Micronaut introspection-aware default for GraphQL beans
- add regression coverage for introspected fields, null-valued properties, and custom default data fetchers
- document the new default property resolution behavior and its native-image impact

## Verification
- ./gradlew :micronaut-graphql:test --tests io.micronaut.configuration.graphql.GraphQLIntrospectionPropertyDataFetcherSpec --tests io.micronaut.configuration.graphql.GraphQLCustomDefaultDataFetcherSpec --tests io.micronaut.configuration.graphql.GraphQLContextPropagationSpec
- ./gradlew :test-suite-graal:nativeTest
- ./gradlew publishGuide docs

Resolves #253
