### PR TITLE
chore(deps): combine renovate dependency batch

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ managed-graphql-spqr = "0.12.4"
 graal-svm = "25.0.3"
 shadow = '9.4.1'
 
-micronaut = "5.0.0-M24"
+micronaut = "5.0.0-RC1"
 micronaut-platform = "4.10.13"
 micronaut-gradle-plugin = "4.6.2"
 micronaut-kotlin = "4.7.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- update the Gradle wrapper distribution from 9.4.1 to 9.5.0
- update `io.micronaut:micronaut-core-bom` from 5.0.0-M24 to 5.0.0-RC1
- combine the still-valid Renovate candidates from #688 and #716 on top of current `5.0.x`

## Verification
- `./gradlew check -q -x japiCmp -x checkVersionCatalogCompatibility`

Resolves #720
