### PR TITLE
Fix GraphQL WS message binding for abstract Message class (#718)

### DIFF
--- a/examples/chat/src/main/java/example/domain/ChatMessage.java
+++ b/examples/chat/src/main/java/example/domain/ChatMessage.java
@@ -15,11 +15,13 @@
  */
 package example.domain;
 
+import io.micronaut.core.annotation.Introspected;
 import java.time.ZonedDateTime;
 
 /**
  * @author Gerard Klijs
  */
+@Introspected
 public class ChatMessage {
 
     private String from;

--- a/examples/chat/src/test/java/example/ChatGraphQLTest.java
+++ b/examples/chat/src/test/java/example/ChatGraphQLTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example;
+
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.http.client.annotation.Client;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+public class ChatGraphQLTest {
+
+    @Inject
+    @Client("/")
+    HttpClient client;
+
+    @Test
+    public void queryMessages() {
+        Map<String, Object> result = execute("{ messages { id text from } }");
+
+        Map<String, Object> data = data(result);
+        List<Map<String, Object>> messages = (List<Map<String, Object>>) data.get("messages");
+        assertNotNull(messages);
+        assertFalse(messages.isEmpty());
+
+        Map<String, Object> firstMessage = messages.getFirst();
+        assertNotNull(firstMessage.get("id"));
+        assertNotNull(firstMessage.get("text"));
+        assertNotNull(firstMessage.get("from"));
+    }
+
+    private Map<String, Object> execute(String query) {
+        Map<String, Object> result = client.toBlocking().retrieve(
+                HttpRequest.POST("/graphql", Map.of("query", query)),
+                Map.class
+        );
+        assertNotNull(result);
+        assertFalse(result.containsKey("errors"));
+        return result;
+    }
+
+    private Map<String, Object> data(Map<String, Object> result) {
+        assertTrue(result.containsKey("data"));
+        return (Map<String, Object>) result.get("data");
+    }
+}

--- a/examples/chat/src/test/java/example/ChatGraphQLTest.java
+++ b/examples/chat/src/test/java/example/ChatGraphQLTest.java
@@ -39,7 +39,9 @@ public class ChatGraphQLTest {
 
     @Test
     public void queryMessages() {
-        Map<String, Object> result = execute("{ messages { id text from } }");
+        execute("mutation { chat(text: \"Hello world\") { from text time } }");
+
+        Map<String, Object> result = execute("{ messages { from text time } }");
 
         Map<String, Object> data = data(result);
         List<Map<String, Object>> messages = (List<Map<String, Object>>) data.get("messages");
@@ -47,9 +49,9 @@ public class ChatGraphQLTest {
         assertFalse(messages.isEmpty());
 
         Map<String, Object> firstMessage = messages.getFirst();
-        assertNotNull(firstMessage.get("id"));
-        assertNotNull(firstMessage.get("text"));
         assertNotNull(firstMessage.get("from"));
+        assertNotNull(firstMessage.get("text"));
+        assertNotNull(firstMessage.get("time"));
     }
 
     private Map<String, Object> execute(String query) {

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/DefaultGraphQLInvocation.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/DefaultGraphQLInvocation.java
@@ -75,7 +75,7 @@ public class DefaultGraphQLInvocation implements GraphQLInvocation {
      * @param graphQL                         the {@link GraphQL} instance
      * @param graphQLExecutionInputCustomizer the {@link GraphQLExecutionInputCustomizer} instance
      * @param dataLoaderRegistry              the {@link DataLoaderRegistry} instance
-     * @deprecated Use {@link DefaultGraphQLInvocation(BeanContext, GraphQLExecutionInputCustomizer, BeanProvider)} instead.
+     * @deprecated Use {@link DefaultGraphQLInvocation} with BeanContext, GraphQLExecutionInputCustomizer, and BeanProvider instead.
      */
     @Deprecated(forRemoval = true, since = "5.1.0")
     public DefaultGraphQLInvocation(

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/GraphQLController.java
@@ -263,7 +263,6 @@ public class GraphQLController {
         }
     }
 
-
     private Publisher<MutableHttpResponse<String>> executeBatchRequests(GraphQLRequestBody[] requests, HttpRequest httpRequest) {
         MutableHttpResponse<String> batchHttpResponse = HttpResponse.status(HttpStatus.OK);
         List<GraphQLRequestBody> batchRequests = requests == null ? Collections.emptyList() : Arrays.asList(requests);

--- a/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsHandler.java
+++ b/graphql/src/main/java/io/micronaut/configuration/graphql/ws/GraphQLWsHandler.java
@@ -19,6 +19,7 @@ import graphql.ExecutionResult;
 import io.micronaut.configuration.graphql.GraphQLConfiguration;
 import io.micronaut.configuration.graphql.GraphQLInvocation;
 import io.micronaut.configuration.graphql.GraphQLInvocationData;
+import io.micronaut.configuration.graphql.GraphQLJsonSerializer;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.HttpRequest;
@@ -65,6 +66,8 @@ public class GraphQLWsHandler {
 
     private final GraphQLWsConfiguration configuration;
 
+    private final GraphQLJsonSerializer graphQLJsonSerializer;
+
     private final ConcurrentSkipListSet<String> connections = new ConcurrentSkipListSet<>();
 
     private final ConcurrentMap<String, Publisher<? extends Message>> subscriptions = new ConcurrentHashMap<>();
@@ -75,11 +78,13 @@ public class GraphQLWsHandler {
      * @param scheduler The task scheduler for handling connection initialisation timeouts.
      * @param graphQLInvocation The graphql invocation helper for executing GraphQL operations.
      * @param configuration The configuration of the graphql-ws support.
+     * @param graphQLJsonSerializer The JSON serializer for deserializing incoming messages.
      */
-    public GraphQLWsHandler(ScheduledExecutorTaskScheduler scheduler, GraphQLInvocation graphQLInvocation, GraphQLWsConfiguration configuration) {
+    public GraphQLWsHandler(ScheduledExecutorTaskScheduler scheduler, GraphQLInvocation graphQLInvocation, GraphQLWsConfiguration configuration, GraphQLJsonSerializer graphQLJsonSerializer) {
         this.scheduler = scheduler;
         this.graphQLInvocation = graphQLInvocation;
         this.configuration = configuration;
+        this.graphQLJsonSerializer = graphQLJsonSerializer;
     }
 
     /**
@@ -106,14 +111,24 @@ public class GraphQLWsHandler {
     /**
      * Called on every message received from the client.
      *
-     * @param message Message received from a client
+     * @param messageStr JSON string received from a client
      * @param session WebSocketSession
      * @return {@code Publisher<Message>}
      */
     @OnMessage
     public Publisher<Message> onMessage(
-        Message message,
+        String messageStr,
         WebSocketSession session) {
+        Message message;
+        try {
+            message = graphQLJsonSerializer.deserialize(messageStr, Message.class);
+        } catch (Exception e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Invalid message received for session id {}: {}", session.getId(), e.getMessage());
+            }
+            session.close(new CloseReason(4400, "Invalid message."));
+            return Mono.empty();
+        }
         if (message instanceof ConnectionInitMessage) {
             if (LOG.isTraceEnabled()) {
                 LOG.trace("Received connection initialisation request for session id {}", session.getId());

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsClient.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsClient.groovy
@@ -1,10 +1,13 @@
 package io.micronaut.configuration.graphql.ws
 
 import io.micronaut.context.annotation.Requires
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
 import io.micronaut.websocket.CloseReason
 import io.micronaut.websocket.annotation.ClientWebSocket
 import io.micronaut.websocket.annotation.OnClose
 import io.micronaut.websocket.annotation.OnMessage
+import jakarta.inject.Inject
 
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.BlockingQueue
@@ -14,13 +17,17 @@ import java.util.concurrent.TimeUnit
 @ClientWebSocket(uri = "\${graphql.graphql-ws.path:/graphql-ws}", subprotocol = "graphql-transport-ws")
 abstract class GraphQLWsClient implements AutoCloseable {
 
+    @Inject
+    private JsonMapper jsonMapper
+
     private BlockingQueue<Message> responses = new ArrayBlockingQueue<>(10)
 
     boolean closed = false;
     CloseReason closeReason = null;
 
     @OnMessage
-    void onMessage(Message message) {
+    void onMessage(String messageStr) {
+        Message message = jsonMapper.readValue(messageStr, Argument.of(Message.class))
         responses.add(message);
     }
 

--- a/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsHandlerSpec.groovy
+++ b/graphql/src/test/groovy/io/micronaut/configuration/graphql/ws/GraphQLWsHandlerSpec.groovy
@@ -14,10 +14,8 @@ import jakarta.inject.Singleton
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import spock.lang.AutoCleanup
-import spock.lang.Ignore
 import spock.lang.Specification
 
-@Ignore("InstantiationError during WebSocket message binding to the abstract Message class")
 class GraphQLWsHandlerSpec extends Specification {
 
     @AutoCleanup


### PR DESCRIPTION
Fix GraphQL WebSocket message binding that fails with `InstantiationError` because Micronaut's argument binder tries to instantiate the abstract sealed `Message` class directly.

## Changes
- **GraphQLWsHandler**: Changed `@OnMessage` parameter from `Message` to `String`, added `GraphQLJsonSerializer` injection for manual deserialization with Jackson polymorphic type resolution
- **GraphQLWsClient** (test): Same `String` parameter change with `JsonMapper` deserialization
- **GraphQLWsHandlerSpec**: Removed `@Ignore` annotation — all 14 tests now pass

## Root cause
The `Message` class uses Jackson's `@JsonTypeInfo`/`@JsonSubTypes` for polymorphic deserialization (concrete type determined by the `type` field). Micronaut's WebSocket `QueryValueArgumentBinder` tries to instantiate the declared parameter type (`Message`) directly via `bindPojo`, which fails because `Message` is abstract.

## How the fix works
By accepting the raw JSON `String` and deserializing with Jackson's ObjectMapper (which correctly resolves the concrete subtype via `@JsonTypeInfo`), polymorphic type resolution works as intended.

All 14 previously-ignored WebSocket test cases pass successfully.